### PR TITLE
Remove dark scheme from root

### DIFF
--- a/public/css/variables.css
+++ b/public/css/variables.css
@@ -1,5 +1,5 @@
 :root {
-    color-scheme: light dark;
+    color-scheme: light;
 
     --opendxp-lime-100: #E6FF2A;
     --opendxp-lime-200: #D4EB27;

--- a/templates/admin/misc/admin_css.html.twig
+++ b/templates/admin/misc/admin_css.html.twig
@@ -45,10 +45,6 @@
 {# CUSTOM BRANDING #}
 {% if adminSettings is defined and adminSettings['branding']['color_admin_interface'] is defined %}
     {% set interfaceColor = adminSettings['branding']['color_admin_interface'] %}
-#opendxp_signet {
-    background-color: {{ interfaceColor }} !important;
-}
-
 #opendxp_avatar {
     background-color: {{ interfaceColor }} !important;
 }


### PR DESCRIPTION
Removed the dark from color-scheme to fix a bug where on dark mode the links and p tags were rendered white.