### PR TITLE
Replace `$request->get()`

### DIFF
--- a/public/js/opendxp/document/editables/renderlet.js
+++ b/public/js/opendxp/document/editables/renderlet.js
@@ -174,7 +174,7 @@ opendxp.document.editables.renderlet = Class.create(opendxp.document.editable, {
         };
 
         Ext.Ajax.request({
-            method: 'get',
+            method: 'GET',
             url: Routing.generate('opendxp_admin_document_renderlet_renderlet'),
             success: function (response) {
                 setContent(response.responseText);

--- a/public/js/opendxp/element/helpers/gridColumnConfig.js
+++ b/public/js/opendxp/element/helpers/gridColumnConfig.js
@@ -86,11 +86,9 @@ opendxp.element.helpers.gridColumnConfig = {
 
         if (this.gridType === 'asset') {
             route = 'opendxp_admin_asset_assethelper_griddeletecolumnconfig';
-        }
-        else if(this.gridType === 'object') {
+        } else if(this.gridType === 'object') {
             route = 'opendxp_admin_dataobject_dataobjecthelper_griddeletecolumnconfig';
-        }
-        else {
+        } else {
             throw new Error('Type unknown');
         }
 
@@ -100,15 +98,15 @@ opendxp.element.helpers.gridColumnConfig = {
                 method: "DELETE",
                 params: {
                     id: this.classId,
-                    objectId:
-                    this.object.id,
+                    objectId: this.object.id,
                     gridtype: "grid",
                     gridConfigId: this.settings.gridConfigId,
                     searchType: this.searchType
                 },
                 success: function (response) {
 
-                    decodedResponse = Ext.decode(response.responseText);
+                    const decodedResponse = Ext.decode(response.responseText);
+
                     if (!decodedResponse.deleteSuccess) {
                         opendxp.helpers.showNotification(t("error"), t("error_deleting_item"), "error");
                     }

--- a/public/js/opendxp/helpers.js
+++ b/public/js/opendxp/helpers.js
@@ -2529,7 +2529,7 @@ opendxp.helpers.markColumnConfigAsFavourite = function (objectId, classId, gridC
                     if (rdata && rdata.success) {
                         opendxp.helpers.showNotification(t("success"), t("saved_successfully"), "success");
 
-                        if (rdata.spezializedConfigs) {
+                        if (rdata.specializedConfigs) {
                             opendxp.helpers.removeOtherConfigs(objectId, classId, gridConfigId, searchType);
                         }
                     }
@@ -2998,13 +2998,6 @@ opendxp.helpers.roles = function() {
     }
 };
 
-opendxp.helpers.clearAllCaches = function() {
-    var user = opendxp.globalmanager.get("user");
-    if ((user.isAllowed("clear_cache") || user.isAllowed("clear_temp_files") || user.isAllowed("clear_fullpage_cache"))) {
-        opendxp.layout.toolbar.prototype.clearCache({'env[]': ['dev','prod']});
-    }
-};
-
 opendxp.helpers.clearDataCache = function() {
     var user = opendxp.globalmanager.get("user");
     if ((user.isAllowed("clear_cache") || user.isAllowed("clear_temp_files") || user.isAllowed("clear_fullpage_cache"))) {
@@ -3039,7 +3032,6 @@ opendxp.helpers.keyBindingMapping = {
     "tagConfiguration": opendxp.helpers.tagConfiguration,
     "users": opendxp.helpers.users,
     "roles": opendxp.helpers.roles,
-    "clearAllCaches": opendxp.helpers.clearAllCaches,
     "clearDataCache": opendxp.helpers.clearDataCache
 };
 

--- a/public/js/opendxp/helpers.js
+++ b/public/js/opendxp/helpers.js
@@ -2513,7 +2513,7 @@ opendxp.helpers.markColumnConfigAsFavourite = function (objectId, classId, gridC
 
         Ext.Ajax.request({
             url: url,
-            method: "post",
+            method: 'POST',
             params: {
                 objectId: objectId,
                 classId: classId,
@@ -2559,10 +2559,10 @@ opendxp.helpers.removeOtherConfigs = function (objectId, classId, gridConfigId, 
         buttons: Ext.Msg.YESNO,
         icon: Ext.MessageBox.INFO,
         fn: function (btn) {
-            if (btn === "yes") {
+            if (btn === 'yes') {
                 Ext.Ajax.request({
                     url: Routing.generate('opendxp_admin_dataobject_dataobjecthelper_gridconfigapplytoall'),
-                    method: "post",
+                    method: 'POST',
                     params: {
                         objectId: objectId,
                         classId: classId,

--- a/public/js/opendxp/layout/toolbar.js
+++ b/public/js/opendxp/layout/toolbar.js
@@ -686,7 +686,7 @@ opendxp.layout.toolbar = Class.create({
                              text: t("all_caches") + ' (Symfony + Data)',
                              iconCls: "opendxp_nav_icon_clear_cache",
                              itemId: 'opendxp_menu_settings_cache_all_caches',
-                             handler: this.clearCache.bind(this, {'env[]': opendxp.settings['environment']})
+                             handler: this.clearCache.bind(this, {env: opendxp.settings['environment']})
                          });
                      }
 
@@ -704,7 +704,7 @@ opendxp.layout.toolbar = Class.create({
                              text: t('symfony_cache'),
                              iconCls: "opendxp_nav_icon_clear_cache",
                              itemId: 'opendxp_menu_settings_cache_symfony',
-                             handler: this.clearCache.bind(this, {'only_symfony_cache': true, 'env[]': opendxp.settings['environment']})
+                             handler: this.clearCache.bind(this, {only_symfony_cache: true, env: opendxp.settings['environment']})
                          });
                      }
 
@@ -1243,10 +1243,10 @@ opendxp.layout.toolbar = Class.create({
 
      clearCache: function (params) {
          Ext.Msg.confirm(t('warning'), t('system_performance_stability_warning'), function(btn){
-             if (btn == 'yes'){
+             if (btn === 'yes'){
                  Ext.Ajax.request({
                      url: Routing.generate('opendxp_admin_settings_clearcache'),
-                     method: "DELETE",
+                     method: 'DELETE',
                      params: params
                  });
              }
@@ -1262,10 +1262,10 @@ opendxp.layout.toolbar = Class.create({
 
      clearTemporaryFiles: function () {
          Ext.Msg.confirm(t('warning'), t('system_performance_stability_warning'), function(btn){
-             if (btn == 'yes'){
+             if (btn === 'yes'){
                  Ext.Ajax.request({
                      url: Routing.generate('opendxp_admin_settings_cleartemporaryfiles'),
-                     method: "DELETE"
+                     method: 'DELETE'
                  });
              }
          });

--- a/public/js/opendxp/object/classificationstore/keySelectionWindow.js
+++ b/public/js/opendxp/object/classificationstore/keySelectionWindow.js
@@ -11,11 +11,8 @@
  * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
  */
 
-opendxp.registerNS("opendxp.object.classificationstore.keySelectionWindow");
-/**
- * @private
- * this is for the object editor and the add key window in the classification store definition
- */
+opendxp.registerNS('opendxp.object.classificationstore.keySelectionWindow');
+
 opendxp.object.classificationstore.keySelectionWindow = Class.create({
     acceptEvents: true,
 
@@ -43,8 +40,8 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
 
         this.searchfield = new Ext.form.field.Text({
             width: 300,
-            style: "float: left;",
-            fieldLabel: t("search"),
+            style: 'float: left;',
+            fieldLabel: t('search'),
             enableKeyEvents: true,
             listeners: {
                 keypress: function (searchField, e, eOpts) {
@@ -58,7 +55,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
         var resultPanel = this.getResultPanel();
         var title = t('classificationstore_dialog_keygroup_search');
         if (this.config.frameName) {
-            title += " - " + t("frame") + " " + this.config.frameName;
+            title += ' - ' + t('frame') + ' ' + this.config.frameName;
         }
 
         this.searchWindow = new Ext.window.Window({
@@ -66,7 +63,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
             width: 850,
             height: 550,
             modal: true,
-            layout: "fit",
+            layout: 'fit',
             items: [resultPanel],
             listeners: {
                 beforeclose: function () {
@@ -74,17 +71,17 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
                 }.bind(this)
             },
             bbar: [
-                "->", {
-                    xtype: "button",
-                    text: t("cancel"),
-                    iconCls: "opendxp_icon_cancel",
+                '->', {
+                    xtype: 'button',
+                    text: t('cancel'),
+                    iconCls: 'opendxp_icon_cancel',
                     handler: function () {
                         this.searchWindow.close();
                     }.bind(this)
                 }, {
-                    xtype: "button",
-                    text: t("apply"),
-                    iconCls: "opendxp_icon_apply",
+                    xtype: 'button',
+                    text: t('apply'),
+                    iconCls: 'opendxp_icon_apply',
                     handler: function () {
                         var selectionModel = this.gridPanel.getSelectionModel();
                         var selected = selectionModel.getSelection();
@@ -98,7 +95,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
                         } else if (this.config.isGroupSearch || this.config.isGroupByKeySearch) {
                             var groupIds = [];
                             for (var i = 0; i < selected.length; i++) {
-                                var groupId = this.config.isGroupSearch ? selected[i].id : selected[i].get("groupId");
+                                var groupId = this.config.isGroupSearch ? selected[i].id : selected[i].get('groupId');
                                 groupIds.push(groupId);
                             }
                             this.addGroups(groupIds);
@@ -120,20 +117,31 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
     },
 
     addCollections: function (collectionIds) {
+
+        let params = {};
+
         if (!this.acceptEvents) {
             return;
         }
         this.acceptEvents = false;
         if (collectionIds.length > 0) {
+
+            params.collectionIds = Ext.util.JSON.encode(collectionIds);
+
+            if (this.config.object) {
+                params.oid = this.config.object.id;
+            }
+
+            if (this.config && this.config.fieldname) {
+                params.fieldname = this.config.fieldname;
+            }
+
             this.config.parent.requestPending.call(this.config.parent);
+
             Ext.Ajax.request({
                 url: Routing.generate('opendxp_admin_dataobject_classificationstore_addcollections'),
                 method: 'POST',
-                params: {
-                    collectionIds: Ext.util.JSON.encode(collectionIds),
-                    oid: this.config.object ? this.config.object.id : null,
-                    fieldname: this.config ? this.config.fieldname : null
-                },
+                params: params,
                 success: function (response) {
                     this.config.parent.handleAddGroups.call(this.config.parent, response);
                     this.searchWindow.close();
@@ -148,6 +156,9 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
     },
 
     addGroups: function (groupIds) {
+
+        let params = {};
+
         if (!this.acceptEvents) {
             return;
         }
@@ -168,15 +179,23 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
         this.acceptEvents = false;
 
         if (groupIds.length > 0) {
+
+            params.groupIds = Ext.util.JSON.encode(groupIds);
+
+            if (this.config.object) {
+                params.oid = this.config.object.id;
+            }
+
+            if (this.config && this.config.fieldname) {
+                params.fieldname = this.config.fieldname;
+            }
+
             this.config.parent.requestPending.call(this.config.parent);
+
             Ext.Ajax.request({
                 url: Routing.generate('opendxp_admin_dataobject_classificationstore_addgroups'),
                 method: 'POST',
-                params: {
-                    groupIds: Ext.util.JSON.encode(groupIds),
-                    oid: this.config.object ? this.config.object.id : null,
-                    fieldname: this.config ? this.config.fieldname : null
-                },
+                params: params,
                 success: function (response) {
                     this.config.parent.handleAddGroups.call(this.config.parent, response);
                     this.searchWindow.close();
@@ -223,9 +242,9 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
 
         if (this.config.enableCollections) {
             this.toolbarbuttons.collection = new Ext.Button({
-                text: t("collection"),
+                text: t('collection'),
                 handler: this.searchCollection.bind(this),
-                iconCls: "opendxp_icon_classificationstore_icon_cs_collections",
+                iconCls: 'opendxp_icon_classificationstore_icon_cs_collections',
                 enableToggle: true,
                 pressed: this.config.isCollectionSearch,
 
@@ -235,9 +254,9 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
 
         if (this.config.enableGroups) {
             this.toolbarbuttons.group = new Ext.Button({
-                text: t("classificationstore_group"),
+                text: t('classificationstore_group'),
                 handler: this.searchGroup.bind(this),
-                iconCls: "opendxp_icon_keys",
+                iconCls: 'opendxp_icon_keys',
                 enableToggle: true,
                 pressed: this.config.isGroupSearch,
                 hidden: !this.config.enableGroups
@@ -247,9 +266,9 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
 
         if (this.config.enableGroupByKey) {
             this.toolbarbuttons.groupByKey = new Ext.Button({
-                text: t("classificationstore_group_by_key"),
+                text: t('classificationstore_group_by_key'),
                 handler: this.searchGroupByKey.bind(this),
-                iconCls: "opendxp_icon_key",
+                iconCls: 'opendxp_icon_key',
                 enableToggle: true,
                 pressed: this.config.isGroupByKeySearch,
 
@@ -260,9 +279,9 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
 
         if (this.config.enableKeys) {
             this.toolbarbuttons.key = new Ext.Button({
-                text: t("key"),
+                text: t('key'),
                 handler: this.searchKey.bind(this),
-                iconCls: "opendxp_icon_key",
+                iconCls: 'opendxp_icon_key',
                 enableToggle: true,
                 pressed: !this.config.isGroupSearch && !this.config.isCollectionSearch,
 
@@ -270,13 +289,13 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
             items.push(this.toolbarbuttons.key);
         }
 
-        items.push("->");
+        items.push('->');
         items.push(this.searchfield);
 
         items.push({
-            xtype: "button",
-            text: t("search"),
-            iconCls: "opendxp_icon_search",
+            xtype: 'button',
+            text: t('search'),
+            iconCls: 'opendxp_icon_search',
             handler: this.applySearchFilter.bind(this)
         });
 
@@ -292,7 +311,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
     applySearchFilter: function () {
         var formValue = this.searchfield.getValue();
 
-        this.store.getProxy().setExtraParam("searchfilter", formValue);
+        this.store.getProxy().setExtraParam('searchfilter', formValue);
 
 
         var lastOptions = this.store.lastOptions;
@@ -332,27 +351,27 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
     },
 
     searchCollection: function () {
-        this.setupSearch("collection", "isCollectionSearch");
+        this.setupSearch('collection', 'isCollectionSearch');
     },
 
     searchGroup: function () {
-        this.setupSearch("group", "isGroupSearch");
+        this.setupSearch('group', 'isGroupSearch');
     },
 
     searchKey: function () {
-        this.setupSearch("key", "key");
+        this.setupSearch('key', 'key');
     },
 
     searchGroupByKey: function () {
-        this.setupSearch("groupByKey", "isGroupByKeySearch");
+        this.setupSearch('groupByKey', 'isGroupByKeySearch');
     },
 
     getResultPanel: function () {
         this.resultPanel = new Ext.Panel({
             tbar: this.getToolbar(),
-            layout: "fit",
+            layout: 'fit',
             style: {
-                backgroundColor: "#0000FF"
+                backgroundColor: '#0000FF'
             }
         });
 
@@ -369,10 +388,14 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
     },
 
     getGridPanel: function () {
-        var postFix;
-        var route;
-        var nameWidth = 200;
-        var descWidth = 590;
+
+        var postFix,
+            route,
+            url,
+            nameWidth = 200,
+            descWidth = 590,
+            readerFields = [],
+            gridColumns = [];
 
         if (this.config.isCollectionSearch) {
             route = 'opendxp_admin_dataobject_classificationstore_collectionsactionget';
@@ -390,22 +413,20 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
         }
 
         if (this.config.isGroupByKeySearch) {
-            var url = Routing.generate('opendxp_admin_dataobject_classificationstore_searchrelations');
+            url = Routing.generate('opendxp_admin_dataobject_classificationstore_searchrelations');
         } else {
-            var url = Routing.generate(route);
+            url = Routing.generate(route);
         }
 
-        var readerFields = [];
         for (var i = 0; i < this.groupFields.length; i++) {
             readerFields.push({name: this.groupFields[i]});
         }
 
-        var gridColumns = [];
         if (this.config.isGroupByKeySearch) {
-            gridColumns.push({text: "ID", width: 60, sortable: true, dataIndex: 'id'});
+            gridColumns.push({text: 'ID', width: 60, sortable: true, dataIndex: 'id'});
 
             gridColumns.push({
-                text: t("group"),
+                text: t('group'),
                 flex: 1,
                 sortable: true,
                 dataIndex: 'groupName',
@@ -414,7 +435,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
             });
 
             gridColumns.push({
-                text: t("name"),
+                text: t('name'),
                 flex: 1,
                 sortable: true,
                 dataIndex: 'keyName',
@@ -423,7 +444,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
             });
 
             gridColumns.push({
-                text: t("description"),
+                text: t('description'),
                 flex: 1,
                 sortable: true,
                 dataIndex: 'keyDescription',
@@ -431,19 +452,10 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
                 renderer: opendxp.helpers.grid.getTranslationColumnRenderer.bind(this)
             });
         } else {
-            gridColumns.push({text: "ID", width: 40, sortable: true, dataIndex: 'id'});
-
-            if (postFix == "properties") {
-                gridColumns.push({
-                    text: t("classificationstore_tag_col_group"),
-                    width: 150,
-                    sortable: true,
-                    dataIndex: 'groupName'
-                });
-            }
+            gridColumns.push({text: 'ID', width: 40, sortable: true, dataIndex: 'id'});
 
             gridColumns.push({
-                text: t("name"),
+                text: t('name'),
                 width: nameWidth,
                 sortable: true,
                 dataIndex: 'name',
@@ -451,7 +463,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
             });
 
             gridColumns.push({
-                text: t("description"),
+                text: t('description'),
                 width: descWidth,
                 sortable: true,
                 dataIndex: 'description',
@@ -497,7 +509,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
             columns: gridColumns,
             loadMask: true,
             columnLines: true,
-            bodyCls: "opendxp_editable_grid",
+            bodyCls: 'opendxp_editable_grid',
             stripeRows: true,
             selModel: Ext.create('Ext.selection.RowModel', {
                 mode: 'MULTI'
@@ -506,7 +518,7 @@ opendxp.object.classificationstore.keySelectionWindow = Class.create({
             listeners: {
                 rowdblclick: function (grid, record, tr, rowIndex, e, eOpts) {
                     if (this.config.isGroupByKeySearch) {
-                        let data = [grid.getStore().getAt(rowIndex).get("groupId")];
+                        let data = [grid.getStore().getAt(rowIndex).get('groupId')];
                         this.addGroups(data);
                     } else {
                         let data = [grid.getStore().getAt(rowIndex).id];

--- a/public/js/opendxp/settings/gdpr/dataproviders/opendxpUsers.js
+++ b/public/js/opendxp/settings/gdpr/dataproviders/opendxpUsers.js
@@ -11,7 +11,7 @@
  * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
  */
 
-opendxp.registerNS("opendxp.settings.gdpr.dataproviders.openDxpUsers");
+opendxp.registerNS('opendxp.settings.gdpr.dataproviders.openDxpUsers');
 /**
  * @private
  */
@@ -29,9 +29,9 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
         if(!this.panel) {
 
             this.panel = new Ext.Panel({
-                title: t("users") + " (OpenDXP)",
-                layout: "border",
-                iconCls: "opendxp_icon_user",
+                title: t('users') + ' (OpenDXP)',
+                layout: 'border',
+                iconCls: 'opendxp_icon_user',
                 closable: false
             });
 
@@ -43,7 +43,7 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
 
     initGrid: function () {
 
-        var user = opendxp.globalmanager.get("user");
+        var user = opendxp.globalmanager.get('user');
 
         this.store = new Ext.data.Store({
             autoDestroy: true,
@@ -59,15 +59,15 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
                 extraParams: this.searchParams
             },
             autoLoad: true,
-            fields: ["id","username","firstname","lastname","email"]
+            fields: ['id','name','firstname','lastname','email']
         });
 
         var columns = [
             {text: 'ID', width: 60, sortable: true, dataIndex: 'id', hidden: false},
-            {text: t("username"), flex: 100, sortable: true, dataIndex: 'username'},
-            {text: t("firstname"), flex: 200, sortable: true, dataIndex: 'firstname'},
-            {text: t("lastname"), flex: 200, sortable: true, dataIndex: 'lastname'},
-            {text: t("email"), flex: 200, sortable: true, dataIndex: 'email'},
+            {text: t('username'), flex: 100, sortable: true, dataIndex: 'name'},
+            {text: t('firstname'), flex: 200, sortable: true, dataIndex: 'firstname'},
+            {text: t('lastname'), flex: 200, sortable: true, dataIndex: 'lastname'},
+            {text: t('email'), flex: 200, sortable: true, dataIndex: 'email'},
             {
                 xtype: 'actioncolumn',
                 menuText: t('gdpr_dataSource_export'),
@@ -75,10 +75,10 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
                 items: [
                     {
                         tooltip: t('gdpr_dataSource_export'),
-                        icon: "/bundles/opendxpadmin/img/flat-color-icons/export.svg",
+                        icon: '/bundles/opendxpadmin/img/flat-color-icons/export.svg',
                         handler: function (grid, rowIndex) {
-                            if (!user.isAllowed("users")) {
-                                opendxp.helpers.showPermissionError("users");
+                            if (!user.isAllowed('users')) {
+                                opendxp.helpers.showPermissionError('users');
                                 return;
                             }
 
@@ -87,7 +87,7 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
                         }.bind(this),
                         getClass: function(v, meta, rec) {
                             if(!user.isAllowed('users')){
-                                return "inactive_actioncolumn";
+                                return 'inactive_actioncolumn';
                             }
                         }
                     }
@@ -100,10 +100,10 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
                 items: [
                     {
                         tooltip: t('remove'),
-                        icon: "/bundles/opendxpadmin/img/flat-color-icons/delete.svg",
+                        icon: '/bundles/opendxpadmin/img/flat-color-icons/delete.svg',
                         handler: function (grid, rowIndex) {
-                            if (!user.isAllowed("users")) {
-                                opendxp.helpers.showPermissionError("users");
+                            if (!user.isAllowed('users')) {
+                                opendxp.helpers.showPermissionError('users');
                                 return;
                             }
 
@@ -115,7 +115,7 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
                                 buttons: Ext.Msg.YESNO ,
                                 icon: Ext.MessageBox.QUESTION,
                                 fn: function (button) {
-                                    if (button == "yes") {
+                                    if (button === 'yes') {
                                         Ext.Ajax.request({
                                             url: Routing.generate('opendxp_admin_user_delete'),
                                             method: 'DELETE',
@@ -132,11 +132,11 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
 
                         }.bind(this),
                         isDisabled: function(view, rowIndex, colIndex, item, record) {
-                            return record.data["__gdprIsDeletable"] == false;
+                            return record.data['__gdprIsDeletable'] == false;
                         },
                         getClass: function(v, meta, rec) {
                             if(!user.isAllowed('users')){
-                                return "inactive_actioncolumn";
+                                return 'inactive_actioncolumn';
                             }
                         }
                     }
@@ -147,7 +147,7 @@ opendxp.settings.gdpr.dataproviders.openDxpUsers = Class.create({
 
         this.pagingtoolbar = opendxp.helpers.grid.buildDefaultPagingToolbar(this.store);
         this.gridPanel = Ext.create('Ext.grid.Panel', {
-            region: "center",
+            region: 'center',
             store: this.store,
             border: false,
             columns: columns,

--- a/public/js/opendxp/workflow/transitionPanel.js
+++ b/public/js/opendxp/workflow/transitionPanel.js
@@ -12,18 +12,14 @@
  */
 
 opendxp.registerNS("opendxp.workflow.transitionPanel");
-/**
- * @private
- */
+
 opendxp.workflow.transitionPanel = Class.create({
 
-    getClassName: function ()
-    {
+    getClassName: function () {
         return "opendxp.workflow.transitionPanel";
     },
 
-    initialize: function(elementType, elementId, elementEditor, workflowName, transitionConfig)
-    {
+    initialize: function (elementType, elementId, elementEditor, workflowName, transitionConfig) {
         this.elementType = elementType;
         this.elementId = elementId;
         this.elementEditor = elementEditor;
@@ -35,45 +31,48 @@ opendxp.workflow.transitionPanel = Class.create({
 
         //show the action window
         this.transitionWindow.show();
-
     },
 
-
-    getFormPanelItems: function()
-    {
-        var items = [{
-            xtype: 'container',
-            itemId: 'workflowMessage',
-            html: ''
-        },{
-            xtype: 'container',
-            itemId: 'customHtmlTop',
-            html: ''
-        },{
-            xtype: 'hiddenfield',
-            name: 'cid',
-            value: this.elementId
-        },{
-            xtype: 'hiddenfield',
-            name: 'ctype',
-            value: this.elementType
-        },{
-            xtype: 'fieldset',
-            title: t('workflow_additional_info'),
-            itemId: 'additionalInfoFieldset',
-            defaults: {
-                labelWidth: 200
+    getFormPanelItems: function () {
+        var items = [
+            {
+                xtype: 'container',
+                itemId: 'workflowMessage',
+                html: ''
             },
-            items: [],
-            hidden: true
-        },{
-            xtype: 'container',
-            itemId: 'customHtmlCenter',
-            html: ''
-        }
+            {
+                xtype: 'container',
+                itemId: 'customHtmlTop',
+                html: ''
+            },
+            {
+                xtype: 'hiddenfield',
+                name: 'cid',
+                value: this.elementId
+            },
+            {
+                xtype: 'hiddenfield',
+                name: 'ctype',
+                value: this.elementType
+            },
+            {
+                xtype: 'fieldset',
+                title: t('workflow_additional_info'),
+                itemId: 'additionalInfoFieldset',
+                defaults: {
+                    labelWidth: 200
+                },
+                items: [],
+                hidden: true
+            },
+            {
+                xtype: 'container',
+                itemId: 'customHtmlCenter',
+                html: ''
+            }
         ];
 
-        if(this.transitionConfig.notes.commentEnabled) {
+        if (this.transitionConfig.notes.commentEnabled) {
 
             var height = this.transitionConfig.notes.additionalFields.length > 0 ? 200 : 300;
 
@@ -105,15 +104,12 @@ opendxp.workflow.transitionPanel = Class.create({
         return items;
     },
 
-    getWorkflowFormPanel: function()
-    {
-
-        if(!this.workflowFormPanel) {
-
+    getWorkflowFormPanel: function () {
+        if (!this.workflowFormPanel) {
             //initialise the formpanel as it doesn't exist
             this.workflowFormPanel = new Ext.form.FormPanel({
                 border: false,
-                frame:false,
+                frame: false,
                 bodyStyle: 'padding:10px',
                 items: this.getFormPanelItems(),
                 defaults: {
@@ -123,23 +119,18 @@ opendxp.workflow.transitionPanel = Class.create({
                 autoScroll: true
             });
 
-
             this.setAdditionalFields(this.transitionConfig.notes.additionalFields);
-
             this.loadCustomHtml();
         }
 
         return this.workflowFormPanel
     },
 
-
     /**
      * Return the value of the transitionPanel form
      * @returns object
      */
-    getWorkflowFormPanelValues: function()
-    {
-
+    getWorkflowFormPanelValues: function () {
         var values = this.getWorkflowFormPanel().getValues();
 
         values.workflowName = this.workflowName;
@@ -147,11 +138,11 @@ opendxp.workflow.transitionPanel = Class.create({
 
         if (this.additionalFields) {
 
-            Ext.each(this.additionalFields, function(cf) {
+            Ext.each(this.additionalFields, function (cf) {
 
                 try {
                     values[cf.getName()] = cf.getValue();
-                } catch(e) {
+                } catch (e) {
                     values[cf.getName()] = '';
                 }
 
@@ -163,11 +154,7 @@ opendxp.workflow.transitionPanel = Class.create({
 
     },
 
-
-
-    getTransitionWindow: function()
-    {
-
+    getTransitionWindow: function () {
         if (!this.transitionWindow) {
             var height = this.getNotesField() ? 510 : 200;
             this.transitionWindow = new Ext.Window({
@@ -176,7 +163,7 @@ opendxp.workflow.transitionPanel = Class.create({
                 iconCls: this.transitionConfig.iconCls,
                 title: t(this.transitionConfig.label),
                 layout: "fit",
-                closeAction:'close',
+                closeAction: 'close',
                 plain: true,
                 maximized: false,
                 autoScroll: true,
@@ -185,11 +172,11 @@ opendxp.workflow.transitionPanel = Class.create({
                     {
                         text: t('cancel'),
                         iconCls: "opendxp_icon_empty",
-                        handler: function(){
+                        handler: function () {
                             this.transitionWindow.hide();
                             this.transitionWindow.destroy();
                         }.bind(this)
-                    },{
+                    }, {
                         text: t('workflow_perform_action'),
                         itemId: 'performActionButton',
                         iconCls: "opendxp_icon_workflow_action",
@@ -206,59 +193,50 @@ opendxp.workflow.transitionPanel = Class.create({
         return this.transitionWindow;
     },
 
-    genericError: function()
-    {
+    genericError: function () {
         this._isLoading = false;
         console.log(arguments);
     },
-
 
     /**
      * Quick accessor for the Notes Field
      * @returns {*|Ext.Component}
      */
-    getNotesField: function()
-    {
+    getNotesField: function () {
         return this.getWorkflowFormPanel().getComponent('notesFieldset') ?
             this.getWorkflowFormPanel().getComponent('notesFieldset').getComponent('notesField') : null;
     },
-
-
 
     /**
      * As the only way to get the submit button is messy, I've created this for it.
      * TODO, find a better way of achieving getting the button
      * Note that non of the regularly documented methods actually work :-(
      */
-    getSubmitButton: function()
-    {
+    getSubmitButton: function () {
         return this.getTransitionWindow().getDockedItems()[1].getComponent('performActionButton');
     },
-
 
     /**
      * Adds a number of additional fields to the additional fields fieldset
      * @param additional
      */
-    setAdditionalFields: function(additional)
-    {
+    setAdditionalFields: function (additional) {
         var additionalFieldset = this.getWorkflowFormPanel().getComponent('additionalInfoFieldset');
 
         //remove all existing fields from the fieldsset first
         additionalFieldset.removeAll();
         this.additionalFields = [];
 
-        Ext.each(additional, function(a) {
+        Ext.each(additional, function (a) {
             //add a new field
-            var field = {};
-            var supportedTags = ['input', 'numeric', 'textarea', 'select', 'datetime', 'date', 'user', 'checkbox'];
+            var field = {},
+                supportedTags = ['input', 'numeric', 'textarea', 'select', 'datetime', 'date', 'user', 'checkbox'],
+                c = a.fieldTypeSettings;
 
-            var c = a.fieldTypeSettings;
             c.name = 'workflow[additional][' + a.name + ']';
             c.fieldType = a.fieldType;
             c.title = a.title;
             c.labelWidth = c.labelWidth ? c.labelWidth : 200;
-
 
             if (in_array(c.fieldType, supportedTags)) {
 
@@ -275,7 +253,7 @@ opendxp.workflow.transitionPanel = Class.create({
                         field.setHeight(100);
                     }
 
-                } catch(e) {
+                } catch (e) {
                     console.error('Could not add additional field');
                     console.info(e);
                 }
@@ -285,7 +263,7 @@ opendxp.workflow.transitionPanel = Class.create({
             additionalFieldset.add(field);
         }, this);
 
-        if(additionalFieldset.items.length) {
+        if (additionalFieldset.items.length) {
             additionalFieldset.show();
         } else {
             additionalFieldset.hide();
@@ -295,12 +273,10 @@ opendxp.workflow.transitionPanel = Class.create({
 
     /**
      * Performs the action selected in the Action Form
-     *
      */
-    submitWorkflowTransition: function()
-    {
+    submitWorkflowTransition: function () {
         var notesField = this.getNotesField();
-        if(notesField && !notesField.validate()) {
+        if (notesField && !notesField.validate()) {
             return; //ui will handle the error
         }
 
@@ -311,18 +287,15 @@ opendxp.workflow.transitionPanel = Class.create({
 
         //send a request to the server with the current form data
         Ext.Ajax.request({
-            url : this.transitionConfig.isGlobalAction ? Routing.generate('opendxp_admin_workflow_submitglobal') : Routing.generate('opendxp_admin_workflow_submitworkflowtransition'),
+            url: this.transitionConfig.isGlobalAction ? Routing.generate('opendxp_admin_workflow_submitglobal') : Routing.generate('opendxp_admin_workflow_submitworkflowtransition'),
             method: 'post',
             params: formvars,
             success: this.onSubmitWorkflowTransitionResponse.bind(this),
             failure: this.genericError.bind(this)
         });
-
-
     },
 
-    onSubmitWorkflowTransitionResponse: function(response)
-    {
+    onSubmitWorkflowTransitionResponse: function (response) {
         var data = Ext.decode(response.responseText);
 
         if (data.success) {
@@ -335,11 +308,13 @@ opendxp.workflow.transitionPanel = Class.create({
             }
 
         } else {
-                this.getWorkflowFormPanel().getComponent('workflowMessage').setHtml(
-                    [
-                        '<div class="action_error">' + t(data.message) + '</div>',
-                        '<div class="action_reason">' + data.reasons.map(function(reason){ return t(reason); }).join('<br>') + '</div>'
-                    ].join(''));
+            this.getWorkflowFormPanel().getComponent('workflowMessage').setHtml(
+                [
+                    '<div class="action_error">' + t(data.message) + '</div>',
+                    '<div class="action_reason">' + data.reasons.map(function (reason) {
+                        return t(reason);
+                    }).join('<br>') + '</div>'
+                ].join(''));
 
             this.getWorkflowFormPanel().scrollTo(0, 0);
 
@@ -348,18 +323,18 @@ opendxp.workflow.transitionPanel = Class.create({
 
     },
 
-    reloadObject: function() {
+    reloadObject: function () {
         this.elementEditor.reload({layoutId: this.transitionConfig.objectLayout});
     },
 
-    loadCustomHtml: function() {
+    loadCustomHtml: function () {
 
         var formvars = this.getWorkflowFormPanelValues();
         formvars['isGlobalAction'] = this.transitionConfig.isGlobalAction;
 
         //send a request to the server with the current form data
         Ext.Ajax.request({
-            url : Routing.generate('opendxp_admin_workflow_modal_custom_html'),
+            url: Routing.generate('opendxp_admin_workflow_modal_custom_html'),
             method: 'post',
             params: formvars,
             success: this.onCustomHtmlResponse.bind(this),
@@ -367,10 +342,11 @@ opendxp.workflow.transitionPanel = Class.create({
         });
     },
 
-    onCustomHtmlResponse: function(response) {
+    onCustomHtmlResponse: function (response) {
 
-        var customHeight = 0;
-        var data = Ext.decode(response.responseText);
+        var customHeight = 0,
+            data = Ext.decode(response.responseText);
+
         if (data.success && data.customHtml) {
             for (var position in data.customHtml) {
                 if (this.getCustomHtmlPositions().includes(position)) {
@@ -387,7 +363,7 @@ opendxp.workflow.transitionPanel = Class.create({
         this.transitionWindow.setHeight(height);
     },
 
-    getCustomHtmlPositions: function() {
+    getCustomHtmlPositions: function () {
         return ['top', 'center', 'bottom']
     }
 });

--- a/public/js/opendxp/workflowmanagement/actionPanel.js
+++ b/public/js/opendxp/workflowmanagement/actionPanel.js
@@ -249,18 +249,18 @@ opendxp.workflowmanagement.actionPanel = Class.create({
         if (this._isLoading) {
             return;
         }
+
         this._isLoading = true;
 
         //send a request to the server with the current form data
         Ext.Ajax.request({
             url : Routing.generate('opendxp_admin_workflow_getworkflowform'),
-            method: 'post',
+            method: 'POST',
             params: this.getWorkflowFormPanel().getValues(),
             success: this.refreshWorkflowFormPanelItems.bind(this),
             failure: this.genericError.bind(this)
         });
     },
-
 
     refreshWorkflowFormPanelItems: function(response)
     {
@@ -292,8 +292,8 @@ opendxp.workflowmanagement.actionPanel = Class.create({
      */
     setAvailableActions: function(actions)
     {
-
         var actionField = this.getWorkflowFormPanel().getComponent('actionFieldset').getComponent('actionField');
+
         actionField.setDisabled(false);
 
         this.actionStore.loadData(actions, false);
@@ -312,8 +312,8 @@ opendxp.workflowmanagement.actionPanel = Class.create({
      */
     setAvailableStates: function(states)
     {
-
         var stateField = this.getWorkflowFormPanel().getComponent('actionFieldset').getComponent('stateField');
+
         stateField.setDisabled(false);
 
         this.stateStore.loadData(states, false);
@@ -338,8 +338,8 @@ opendxp.workflowmanagement.actionPanel = Class.create({
      */
     setAvailableStatuses: function(statuses)
     {
-
         var statusField = this.getWorkflowFormPanel().getComponent('actionFieldset').getComponent('statusField');
+
         statusField.setDisabled(false);
 
         this.statusStore.loadData(statuses, false);
@@ -383,6 +383,7 @@ opendxp.workflowmanagement.actionPanel = Class.create({
     setNotesRequired: function(required)
     {
         var notesField = this.getNotesField();
+
         notesField.allowBlank = !required;
         notesField.setValue(null);
 
@@ -495,8 +496,6 @@ opendxp.workflowmanagement.actionPanel = Class.create({
             success: this.onSubmitWorkflowTransitionResponse.bind(this),
             failure: this.genericError.bind(this)
         });
-
-
     },
 
     onSubmitWorkflowTransitionResponse: function(response)

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -1175,7 +1175,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             if ($request->query->get('config')) {
                 $thumbnailConfig = $image->getThumbnail($this->decodeJson($request->query->get('config')))->getConfig();
             } else {
-                $thumbnailConfig = $image->getThumbnail([...$request->request->all(), ...$request->query->all()])->getConfig();
+                $thumbnailConfig = $image->getThumbnail($request->query->all())->getConfig();
             }
         } else {
             // no high-res images in admin mode (editmode)
@@ -1294,10 +1294,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             throw $this->createAccessDeniedException('not allowed to view thumbnail');
         }
 
-        $thumbnail = [...$request->request->all(), ...$request->query->all()];
+        $thumbnailConfig = $request->query->all();
 
         if ($request->query->has('treepreview')) {
-            $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
+            $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
         $time = null;
@@ -1322,7 +1322,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $video->save();
         }
 
-        $thumb = $video->getImageThumbnail($thumbnail, $time, $image);
+        $thumb = $video->getImageThumbnail($thumbnailConfig, $time, $image);
 
         if ($request->query->get('origin') === 'treeNode' && !$thumb->exists()) {
             OpenDxp::getContainer()->get('messenger.bus.opendxp-core')->dispatch(
@@ -1643,7 +1643,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         EventDispatcherInterface $eventDispatcher,
         GridHelperService $gridHelperService): JsonResponse
     {
-        $allParams = [...$request->request->all(), ...$request->query->all()];
+        $allParams = $request->query->all();
 
         $filterPrepareEvent = new GenericEvent($this, [
             'requestParams' => $allParams,

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -2041,7 +2041,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $asset = Asset::getById((int) $request->query->get('parentId'));
 
         $filePath = null;
-        if($request->files->has('Filedata')) {
+        if ($request->files->has('Filedata')) {
             /** @var UploadedFile $file */
             $file = $request->files->get('Filedata');
             $filePath = $file->getPathname();

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -1954,7 +1954,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 $db = \OpenDxp\Db::get();
                 $conditionFilters = [];
 
-                $selectedIds = $request->query->get('selectedIds', []);
+                $selectedIds = $request->query->get('selectedIds', null);
 
                 if (!empty($selectedIds)) {
                     $selectedIds = explode(',', $selectedIds);
@@ -2391,7 +2391,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $page = $request->query->get('page');
         $text = null;
         if ($asset instanceof Asset\Document) {
-            $text = $asset->getText($page);
+            $text = $asset->getText(empty($page) ? null : (int)$page);
         }
 
         return $this->adminJson(['success' => 'true', 'text' => $text]);

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -54,6 +54,7 @@ use RuntimeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -244,13 +245,13 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/tree-get-children-by-id', name: 'opendxp_admin_asset_treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
-        $allParams = [...$request->request->all(), ...$request->query->all()];
+        $allParams = $request->query->all();
 
         $assets = [];
         $cv = [];
         $asset = Asset::getById((int) $allParams['node']);
 
-        $filter = $request->get('filter');
+        $filter = $request->query->get('filter');
         $limit = (int)$allParams['limit'];
         if (!is_null($filter)) {
             if (!str_ends_with($filter, '*')) {
@@ -322,8 +323,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 'total' => $asset->getChildAmount($this->getAdminUser()),
                 'overflow' => !is_null($filter) && ($filteredTotalCount > $limit),
                 'nodes' => $assets,
-                'filter' => $request->get('filter') ?: '',
-                'inSearch' => (int)$request->get('inSearch'),
+                'filter' => $request->query->get('filter') ?: '',
+                'inSearch' => (int)$request->query->get('inSearch'),
             ]);
         }
 
@@ -388,9 +389,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/exists', name: 'opendxp_admin_asset_exists', methods: ['GET'])]
     public function existsAction(Request $request): JsonResponse
     {
-        $parentAsset = \OpenDxp\Model\Asset::getById((int)$request->get('parentId'));
+        $parentAsset = \OpenDxp\Model\Asset::getById((int)$request->query->get('parentId'));
 
-        $dir = $request->get('dir', '');
+        $dir = $request->query->get('dir', '');
         if ($dir) {
             // this is for uploading folders with Drag&Drop
             // param "dir" contains the relative path of the file
@@ -400,7 +401,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $dir =  '/' . trim($dir, '/ ');
         }
 
-        $assetPath = $parentAsset->getRealFullPath() . $dir . '/' . $request->get('filename');
+        $assetPath = $parentAsset->getRealFullPath() . $dir . '/' . $request->query->get('filename');
 
         return new JsonResponse([
             'exists' => Asset\Service::pathExists($assetPath),
@@ -416,13 +417,15 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     {
         $defaultUploadPath = $config['assets']['default_upload_path'] ?? '/';
 
-        if (array_key_exists('Filedata', $_FILES)) {
-            $filename = $_FILES['Filedata']['name'];
-            $sourcePath = $_FILES['Filedata']['tmp_name'];
-        } elseif ($request->get('type') == 'base64') {
-            $filename = $request->get('filename');
-            $sourcePath = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/upload-base64' . uniqid() . '.tmp';
-            $data = preg_replace('@^data:[^,]+;base64,@', '', $request->get('data'));
+        if ($request->files->has('Filedata')) {
+            /** @var UploadedFile $file */
+            $file = $request->files->get('Filedata');
+            $filename = $file->getClientOriginalName();
+            $sourcePath = $file->getPathname();
+        } elseif ($request->request->get('type') === 'base64') {
+            $filename = $request->request->get('filename');
+            $sourcePath = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/upload-base64' . uniqid('', false) . '.tmp';
+            $data = preg_replace('@^data:[^,]+;base64,@', '', $request->request->get('data'));
             $filesystem = new Filesystem();
             $filesystem->dumpFile($sourcePath, base64_decode($data));
         } else {
@@ -432,11 +435,11 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $parentId = $request->query->getInt('parentId');
         $parentPath = $request->query->get('parentPath');
 
-        if ($request->get('dir') && $request->get('parentId')) {
+        if ($request->query->has('dir') && $request->query->has('parentId')) {
             // this is for uploading folders with Drag&Drop
             // param "dir" contains the relative path of the file
-            $parent = Asset::getById((int) $request->get('parentId'));
-            $dir = $request->get('dir');
+            $parent = Asset::getById((int) $request->query->get('parentId'));
+            $dir = $request->query->get('dir');
             if (str_contains($dir, '..')) {
                 throw new Exception('not allowed');
             }
@@ -463,7 +466,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             if ($newParent) {
                 $parentId = $newParent->getId();
             }
-        } elseif (!$request->get('parentId') && $parentPath) {
+        } elseif (!$request->query->get('parentId') && $parentPath) {
             $parent = Asset::getByPath($parentPath);
             if ($parent instanceof Asset\Folder) {
                 $parentId = $parent->getId();
@@ -477,7 +480,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             throw new Exception('The filename of the asset is empty');
         }
 
-        $context = $request->get('context');
+        $context = $request->query->get('context');
         if ($context) {
             $context = json_decode($context, true);
             $context = $context ?: [];
@@ -498,7 +501,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $parentAsset = Asset::getById((int)$parentId);
 
-        if (!$request->get('allowOverwrite')) {
+        if (!$request->query->get('allowOverwrite')) {
             // check for duplicate filename
             $filename = $this->getSafeFilename($parentAsset->getRealFullPath(), $filename);
         }
@@ -517,7 +520,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         // check if there is a requested type and if matches the asset type of the uploaded file
-        $uploadAssetType = $request->get('uploadAssetType');
+        $uploadAssetType = $request->query->get('uploadAssetType');
         if ($uploadAssetType) {
             $mimetype = MimeTypes::getDefault()->guessMimeType($sourcePath);
             $assetType = Asset::getTypeFromMimeMapping($mimetype, $filename);
@@ -527,7 +530,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             }
         }
 
-        if ($request->get('allowOverwrite') && Asset\Service::pathExists($parentAsset->getRealFullPath().'/'.$filename)) {
+        if ($request->query->get('allowOverwrite') && Asset\Service::pathExists($parentAsset->getRealFullPath().'/'.$filename)) {
             $asset = Asset::getByPath($parentAsset->getRealFullPath().'/'.$filename);
             $asset->setStream(fopen($sourcePath, 'rb', false, File::getContext()));
             $asset->save();
@@ -575,10 +578,13 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/replace-asset', name: 'opendxp_admin_asset_replaceasset', methods: ['POST', 'PUT'])]
     public function replaceAssetAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
 
-        $newFilename = Element\Service::getValidKey($_FILES['Filedata']['name'], 'asset');
-        $mimetype = MimeTypes::getDefault()->guessMimeType($_FILES['Filedata']['tmp_name']);
+        /** @var UploadedFile $file */
+        $file = $request->files->get('Filedata');
+
+        $newFilename = Element\Service::getValidKey($file->getClientOriginalName(), 'asset');
+        $mimetype = MimeTypes::getDefault()->guessMimeType($file->getPathname());
         $newType = Asset::getTypeFromMimeMapping($mimetype, $newFilename);
 
         if ($newType !== $asset->getType()) {
@@ -588,12 +594,14 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             ]);
         }
 
-        $stream = fopen($_FILES['Filedata']['tmp_name'], 'r+');
+        $stream = fopen($file->getPathname(), 'rb+');
         $asset->setStream($stream);
         $asset->setCustomSetting('thumbnails', null);
+
         if (method_exists($asset, 'getEmbeddedMetaData')) {
             $asset->getEmbeddedMetaData(true);
         }
+
         $asset->setUserModification($this->getAdminUser()->getId());
 
         $newFileExt = pathinfo($newFilename, PATHINFO_EXTENSION);
@@ -627,13 +635,13 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function addFolderAction(Request $request): JsonResponse
     {
         $success = false;
-        $parentAsset = Asset::getById((int)$request->get('parentId'));
-        $equalAsset = Asset::getByPath($parentAsset->getRealFullPath() . '/' . $request->get('name'));
+        $parentAsset = Asset::getById((int)$request->request->get('parentId'));
+        $equalAsset = Asset::getByPath($parentAsset->getRealFullPath() . '/' . $request->request->get('name'));
 
         if ($parentAsset->isAllowed('create')) {
             if (!$equalAsset) {
-                $asset = Asset::create($request->get('parentId'), [
-                    'filename' => $request->get('name'),
+                $asset = Asset::create($request->request->get('parentId'), [
+                    'filename' => $request->request->get('name'),
                     'type' => 'folder',
                     'userOwner' => $this->getAdminUser()->getId(),
                     'userModification' => $this->getAdminUser()->getId(),
@@ -650,14 +658,14 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/delete', name: 'opendxp_admin_asset_delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
-        $type = $request->get('type');
+        $type = $request->request->get('type');
 
         if ($type === 'children') {
-            $parentAsset = Asset::getById((int) $request->get('id'));
+            $parentAsset = Asset::getById((int) $request->request->get('id'));
 
             $list = new Asset\Listing();
             $list->setCondition('`path` LIKE ?', [Helper::escapeLike($parentAsset->getRealFullPath()) . '/%']);
-            $list->setLimit((int)$request->get('amount'));
+            $list->setLimit((int)$request->request->get('amount'));
             $list->setOrderKey('LENGTH(`path`)', false);
             $list->setOrder('DESC');
 
@@ -671,8 +679,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             return $this->adminJson(['success' => true, 'deleted' => $deletedItems]);
         }
-        if ($request->get('id')) {
-            $asset = Asset::getById((int) $request->get('id'));
+        if ($request->request->has('id')) {
+            $asset = Asset::getById((int) $request->request->get('id'));
             if ($asset && $asset->isAllowed('delete')) {
                 if ($asset->isLocked()) {
                     return $this->adminJson([
@@ -711,12 +719,12 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $updateData = [...$request->request->all(), ...$request->query->all()];
 
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->request->get('id'));
         if ($asset->isAllowed('settings')) {
             $asset->setUserModification($this->getAdminUser()->getId());
 
             // if the position is changed the path must be changed || also from the children
-            if ($parentId = $request->get('parentId')) {
+            if ($parentId = $request->request->get('parentId')) {
                 $parentAsset = Asset::getById((int) $parentId);
 
                 //check if parent is changed i.e. asset is moved
@@ -744,7 +752,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             }
 
             if ($allowUpdate) {
-                if ($request->get('filename') != $asset->getFilename() && !$asset->isAllowed('rename')) {
+                if ($request->request->get('filename') != $asset->getFilename() && !$asset->isAllowed('rename')) {
                     unset($updateData['filename']);
                     Logger::debug('prevented renaming asset because of missing permissions.');
                 }
@@ -767,10 +775,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
                 return $this->adminJson(['success' => false, 'message' => $msg]);
             }
-        } elseif ($asset->isAllowed('rename') && $request->get('filename')) {
+        } elseif ($asset->isAllowed('rename') && $request->request->has('filename')) {
             //just rename
             try {
-                $asset->setFilename($request->get('filename'));
+                $asset->setFilename($request->request->get('filename'));
                 $asset->save();
                 $data = [
                     'success' => true,
@@ -792,7 +800,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/save', name: 'opendxp_admin_asset_save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->request->get('id'));
 
         if (!$asset) {
             throw $this->createNotFoundException('Asset not found');
@@ -800,8 +808,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         if ($asset->isAllowed('publish')) {
             // metadata
-            if ($request->get('metadata')) {
-                $metadata = $this->decodeJson($request->get('metadata'));
+            if ($request->request->has('metadata')) {
+                $metadata = $this->decodeJson($request->request->get('metadata'));
 
                 $metadataEvent = new GenericEvent($this, [
                     'id' => $asset->getId(),
@@ -817,9 +825,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             }
 
             // properties
-            if ($request->get('properties')) {
+            if ($request->request->has('properties')) {
                 $properties = [];
-                $propertiesData = $this->decodeJson($request->get('properties'));
+                $propertiesData = $this->decodeJson($request->request->get('properties'));
 
                 if (is_array($propertiesData)) {
                     foreach ($propertiesData as $propertyName => $propertyData) {
@@ -845,14 +853,14 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             $this->applySchedulerDataToElement($request, $asset, $this->getAdminUser());
 
-            if ($request->get('data')) {
-                $asset->setData($request->get('data'));
+            if ($request->request->get('data')) {
+                $asset->setData($request->request->get('data'));
             }
 
             // image specific data
             if ($asset instanceof Asset\Image) {
-                if ($request->get('image')) {
-                    $imageData = $this->decodeJson($request->get('image'));
+                if ($request->request->has('image')) {
+                    $imageData = $this->decodeJson($request->request->get('image'));
                     if (isset($imageData['focalPoint'])) {
                         $asset->setCustomSetting('focalPointX', $imageData['focalPoint']['x']);
                         $asset->setCustomSetting('focalPointY', $imageData['focalPoint']['y']);
@@ -865,7 +873,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             }
 
             $asset->setUserModification($this->getAdminUser()->getId());
-            if ($request->get('task') === 'session') {
+            if ($request->request->get('task') === 'session') {
                 // save to session only
                 Asset\Service::saveElementToSession($asset, $request->getSession()->getId());
             } else {
@@ -890,7 +898,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/publish-version', name: 'opendxp_admin_asset_publishversion', methods: ['POST'])]
     public function publishVersionAction(Request $request): JsonResponse
     {
-        $id = (int)$request->get('id');
+        $id = (int)$request->request->get('id');
         $version = Model\Version::getById($id);
         $asset = $version?->loadData();
 
@@ -918,7 +926,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/show-version', name: 'opendxp_admin_asset_showversion', methods: ['GET'])]
     public function showVersionAction(Request $request, Environment $twig): Response
     {
-        $id = (int)$request->get('id');
+        $id = (int)$request->query->get('id');
         $version = Model\Version::getById($id);
         $asset = $version?->loadData();
         if (!$asset) {
@@ -960,7 +968,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/download', name: 'opendxp_admin_asset_download', methods: ['GET'])]
     public function downloadAction(Request $request): StreamedResponse
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
 
         if (!$asset) {
             throw $this->createNotFoundException('Asset not found');
@@ -988,7 +996,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/download-image-thumbnail', name: 'opendxp_admin_asset_downloadimagethumbnail', methods: ['GET'])]
     public function downloadImageThumbnailAction(Request $request): BinaryFileResponse
     {
-        $image = Asset\Image::getById((int) $request->get('id'));
+        $image = Asset\Image::getById((int) $request->query->get('id'));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');
@@ -1000,13 +1008,13 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $config = null;
         $thumbnail = null;
-        $thumbnailName = $request->get('thumbnail');
+        $thumbnailName = $request->query->get('thumbnail');
         $thumbnailFile = null;
         $deleteThumbnail = true;
 
-        if ($request->get('config')) {
-            $config = $this->decodeJson($request->get('config'));
-        } elseif ($request->get('type')) {
+        if ($request->query->has('config')) {
+            $config = $this->decodeJson($request->query->get('config'));
+        } elseif ($request->query->has('type')) {
             $predefined = [
                 'web' => [
                     'resize_mode' => 'scaleByWidth',
@@ -1031,7 +1039,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 ],
             ];
 
-            $config = $predefined[$request->get('type')];
+            $config = $predefined[$request->query->get('type')];
         } elseif ($thumbnailName) {
             $thumbnail = $image->getThumbnail($thumbnailName);
             $deleteThumbnail = false;
@@ -1039,7 +1047,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         if ($config) {
             $thumbnailConfig = new Asset\Image\Thumbnail\Config();
-            $thumbnailConfig->setName('opendxp-download-' . $image->getId() . '-' . md5($request->get('config')));
+            $thumbnailConfig->setName('opendxp-download-' . $image->getId() . '-' . md5($request->query->get('config')));
 
             if ($config['resize_mode'] === 'scaleByWidth') {
                 $thumbnailConfig->addItem('scaleByWidth', [
@@ -1117,7 +1125,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/get-asset', name: 'opendxp_admin_asset_getasset', methods: ['GET'])]
     public function getAssetAction(Request $request): StreamedResponse
     {
-        $image = Asset::getById((int)$request->get('id'));
+        $image = Asset::getById((int)$request->query->get('id'));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');
@@ -1147,8 +1155,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/get-image-thumbnail', name: 'opendxp_admin_asset_getimagethumbnail', methods: ['GET'])]
     public function getImageThumbnailAction(Request $request): BinaryFileResponse|JsonResponse|StreamedResponse
     {
-        $fileinfo = $request->get('fileinfo');
-        $image = Asset\Image::getById((int)$request->get('id'));
+        $fileinfo = $request->query->get('fileinfo');
+        $image = Asset\Image::getById((int)$request->query->get('id'));
 
         if (!$image) {
             throw $this->createNotFoundException('Asset not found');
@@ -1160,12 +1168,12 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $thumbnailConfig = null;
 
-        if ($request->get('thumbnail')) {
-            $thumbnailConfig = $image->getThumbnail($request->get('thumbnail'))->getConfig();
+        if ($request->query->get('thumbnail')) {
+            $thumbnailConfig = $image->getThumbnail($request->query->get('thumbnail'))->getConfig();
         }
         if (!$thumbnailConfig) {
-            if ($request->get('config')) {
-                $thumbnailConfig = $image->getThumbnail($this->decodeJson($request->get('config')))->getConfig();
+            if ($request->query->get('config')) {
+                $thumbnailConfig = $image->getThumbnail($this->decodeJson($request->query->get('config')))->getConfig();
             } else {
                 $thumbnailConfig = $image->getThumbnail([...$request->request->all(), ...$request->query->all()])->getConfig();
             }
@@ -1182,29 +1190,31 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $thumbnailConfig->setRasterizeSVG(true);
         }
 
-        if ($request->get('treepreview')) {
+        if ($request->query->get('treepreview')) {
             $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
             $exists = $image->getThumbnail($thumbnailConfig)->exists();
             if (!$exists) {
-                if ($request->get('origin') === 'treeNode') {
+                if ($request->query->get('origin') === 'treeNode') {
                     OpenDxp::getContainer()->get('messenger.bus.opendxp-core')->dispatch(
                         new AssetPreviewImageMessage($image->getId())
                     );
 
                     throw $this->createNotFoundException(sprintf('Tree preview thumbnail not available for asset %s', $image->getId()));
-                } elseif ($request->get('origin') === 'folderPreview') {
+                }
+
+                if ($request->query->get('origin') === 'folderPreview') {
                     return new BinaryFileResponse(OPENDXP_WEB_ROOT . '/bundles/opendxpadmin/img/video-loading.gif');
                 }
             }
         }
 
-        $cropPercent = $request->get('cropPercent');
+        $cropPercent = $request->query->get('cropPercent');
         if ($cropPercent && filter_var($cropPercent, FILTER_VALIDATE_BOOLEAN)) {
             $thumbnailConfig->addItemAt(0, 'cropPercent', [
-                'width' => $request->get('cropWidth'),
-                'height' => $request->get('cropHeight'),
-                'y' => $request->get('cropTop'),
-                'x' => $request->get('cropLeft'),
+                'width' => $request->query->get('cropWidth'),
+                'height' => $request->query->get('cropHeight'),
+                'y' => $request->query->get('cropTop'),
+                'x' => $request->query->get('cropLeft'),
             ]);
 
             $thumbnailConfig->generateAutoName();
@@ -1239,10 +1249,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/get-folder-thumbnail', name: 'opendxp_admin_asset_getfolderthumbnail', methods: ['GET'])]
     public function getFolderThumbnailAction(Request $request): StreamedResponse
     {
-        $folder = null;
-
-        if ($request->get('id')) {
-            $folder = Asset\Folder::getById((int)$request->get('id'));
+        if ($request->query->has('id')) {
+            $folder = Asset\Folder::getById((int)$request->query->get('id'));
             if ($folder instanceof  Asset\Folder) {
                 if (!$folder->isAllowed('view')) {
                     throw $this->createAccessDeniedException('not allowed to view thumbnail');
@@ -1272,10 +1280,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     {
         $video = null;
 
-        if ($request->get('id')) {
-            $video = Asset\Video::getById((int)$request->get('id'));
-        } elseif ($request->get('path')) {
-            $video = Asset\Video::getByPath($request->get('path'));
+        if ($request->query->has('id')) {
+            $video = Asset\Video::getById((int)$request->query->get('id'));
+        } elseif ($request->query->has('path')) {
+            $video = Asset\Video::getByPath($request->query->get('path'));
         }
 
         if (!$video) {
@@ -1288,27 +1296,27 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $thumbnail = [...$request->request->all(), ...$request->query->all()];
 
-        if ($request->get('treepreview')) {
+        if ($request->query->has('treepreview')) {
             $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
         $time = null;
-        if (is_numeric($request->get('time'))) {
-            $time = (int)$request->get('time');
+        if (is_numeric($request->query->get('time'))) {
+            $time = (int)$request->query->get('time');
         }
 
-        if ($request->get('settime')) {
+        if ($request->query->has('settime')) {
             $video->removeCustomSetting('image_thumbnail_asset');
             $video->setCustomSetting('image_thumbnail_time', $time);
             $video->save();
         }
 
         $image = null;
-        if ($request->get('image')) {
-            $image = Asset\Image::getById((int)$request->get('image'));
+        if ($request->query->has('image')) {
+            $image = Asset\Image::getById((int)$request->query->get('image'));
         }
 
-        if ($request->get('setimage') && $image) {
+        if ($request->query->has('setimage') && $image) {
             $video->removeCustomSetting('image_thumbnail_time');
             $video->setCustomSetting('image_thumbnail_asset', $image->getId());
             $video->save();
@@ -1316,7 +1324,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $thumb = $video->getImageThumbnail($thumbnail, $time, $image);
 
-        if ($request->get('origin') === 'treeNode' && !$thumb->exists()) {
+        if ($request->query->get('origin') === 'treeNode' && !$thumb->exists()) {
             OpenDxp::getContainer()->get('messenger.bus.opendxp-core')->dispatch(
                 new AssetPreviewImageMessage($video->getId())
             );
@@ -1343,7 +1351,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/get-document-thumbnail', name: 'opendxp_admin_asset_getdocumentthumbnail', methods: ['GET'])]
     public function getDocumentThumbnailAction(Request $request): BinaryFileResponse|StreamedResponse
     {
-        $document = Asset\Document::getById((int)$request->get('id'));
+        $document = Asset\Document::getById((int)$request->query->get('id'));
 
         if (!$document) {
             throw $this->createNotFoundException('could not load document asset');
@@ -1353,25 +1361,25 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             throw $this->createAccessDeniedException('not allowed to view thumbnail');
         }
 
-        $thumbnail = Asset\Image\Thumbnail\Config::getByAutoDetect([...$request->request->all(), ...$request->query->all()]);
+        $thumbnail = Asset\Image\Thumbnail\Config::getByAutoDetect($request->query->all());
 
         $format = strtolower($thumbnail->getFormat());
         if ($format === 'source') {
             $thumbnail->setFormat('jpeg'); // default format for documents is JPEG not PNG (=too big)
         }
 
-        if ($request->get('treepreview')) {
+        if ($request->query->get('treepreview')) {
             $thumbnail = Asset\Image\Thumbnail\Config::getPreviewConfig();
         }
 
         $page = 1;
-        if (is_numeric($request->get('page'))) {
-            $page = (int)$request->get('page');
+        if (is_numeric($request->query->get('page'))) {
+            $page = (int)$request->query->get('page');
         }
 
         $thumb = $document->getImageThumbnail($thumbnail, $page);
 
-        if ($request->get('origin') === 'treeNode' && !$thumb->exists()) {
+        if ($request->query->get('origin') === 'treeNode' && !$thumb->exists()) {
             OpenDxp::getContainer()->get('messenger.bus.opendxp-core')->dispatch(
                 new AssetPreviewImageMessage($document->getId())
             );
@@ -1410,7 +1418,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/get-preview-document', name: 'opendxp_admin_asset_getpreviewdocument', methods: ['GET'])]
     public function getPreviewDocumentAction(Request $request): StreamedResponse|Response
     {
-        $asset = Asset\Document::getById((int) $request->get('id'));
+        $asset = Asset\Document::getById((int) $request->query->get('id'));
 
         if (!$asset instanceof Asset\Document) {
             throw $this->createNotFoundException('could not load document asset');
@@ -1507,8 +1515,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/get-preview-video', name: 'opendxp_admin_asset_getpreviewvideo', methods: ['GET'])]
     public function getPreviewVideoAction(Request $request): Response
     {
-        $asset = Asset\Video::getById((int) $request->get('id'));
-        $configName = $request->get('config');
+        $asset = Asset\Video::getById((int) $request->query->get('id'));
+        $configName = $request->query->get('config');
 
         if (!$asset) {
             throw $this->createNotFoundException('could not load video asset');
@@ -1533,7 +1541,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $previewData['thumbnail'] = $thumbnail;
             $previewData['config'] = $config->getName();
 
-            if ($thumbnail['status'] == 'finished') {
+            if ($thumbnail['status'] === 'finished') {
                 return $this->render(
                     '@OpenDxpAdmin/admin/asset/get_preview_video_display.html.twig',
                     $previewData
@@ -1555,8 +1563,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/serve-video-preview', name: 'opendxp_admin_asset_servevideopreview', methods: ['GET'])]
     public function serveVideoPreviewAction(Request $request): StreamedResponse
     {
-        $asset = Asset\Video::getById((int) $request->get('id'));
-        $configName = $request->get('config');
+        $asset = Asset\Video::getById((int) $request->query->get('id'));
+        $configName = $request->query->get('config');
 
         if (!$asset) {
             throw $this->createNotFoundException('could not load video asset');
@@ -1595,7 +1603,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/image-editor', name: 'opendxp_admin_asset_imageeditor', methods: ['GET'])]
     public function imageEditorAction(Request $request): Response
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
 
         if (!$asset->isAllowed('view')) {
             throw $this->createAccessDeniedException('Not allowed to preview');
@@ -1610,7 +1618,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/image-editor-save', name: 'opendxp_admin_asset_imageeditorsave', methods: ['PUT'])]
     public function imageEditorSaveAction(Request $request): JsonResponse
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
 
         if (!$asset) {
             throw $this->createNotFoundException('Asset not found');
@@ -1620,7 +1628,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             throw $this->createAccessDeniedException('not allowed to publish');
         }
 
-        $data = $request->get('dataUri');
+        $data = $request->request->get('dataUri');
         $data = substr($data, strpos($data, ','));
         $data = base64_decode($data);
         $asset->setData($data);
@@ -1724,12 +1732,12 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $transactionId = time();
         $pasteJobs = [];
 
-        Tool\Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($transactionId): void {
+        Tool\Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($transactionId): void {
             $session->set((string) $transactionId, []);
         }, 'opendxp_copy');
 
-        if ($request->get('type') == 'recursive') {
-            $asset = Asset::getById((int) $request->get('sourceId'));
+        if ($request->query->get('type') === 'recursive') {
+            $asset = Asset::getById((int) $request->query->get('sourceId'));
 
             if (!$asset) {
                 throw $this->createNotFoundException('Source not found');
@@ -1740,8 +1748,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 'url' => $this->generateUrl('opendxp_admin_asset_copy'),
                 'method' => 'POST',
                 'params' => [
-                    'sourceId' => $request->get('sourceId'),
-                    'targetId' => $request->get('targetId'),
+                    'sourceId' => $request->query->get('sourceId'),
+                    'targetId' => $request->query->get('targetId'),
                     'type' => 'child',
                     'transactionId' => $transactionId,
                     'saveParentId' => true,
@@ -1763,8 +1771,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                             'method' => 'POST',
                             'params' => [
                                 'sourceId' => $id,
-                                'targetParentId' => $request->get('targetId'),
-                                'sourceParentId' => $request->get('sourceId'),
+                                'targetParentId' => $request->query->get('targetId'),
+                                'sourceParentId' => $request->query->get('sourceId'),
                                 'type' => 'child',
                                 'transactionId' => $transactionId,
                             ],
@@ -1772,15 +1780,15 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     }
                 }
             }
-        } elseif ($request->get('type') == 'child' || $request->get('type') == 'replace') {
+        } elseif ($request->query->get('type') === 'child' || $request->query->get('type') === 'replace') {
             // the object itself is the last one
             $pasteJobs[] = [[
                 'url' => $this->generateUrl('opendxp_admin_asset_copy'),
                 'method' => 'POST',
                 'params' => [
-                    'sourceId' => $request->get('sourceId'),
-                    'targetId' => $request->get('targetId'),
-                    'type' => $request->get('type'),
+                    'sourceId' => $request->query->get('sourceId'),
+                    'targetId' => $request->query->get('targetId'),
+                    'type' => $request->query->get('type'),
                     'transactionId' => $transactionId,
                 ],
             ]];
@@ -1795,21 +1803,21 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function copyAction(Request $request): JsonResponse
     {
         $success = false;
-        $sourceId = (int)$request->get('sourceId');
+        $sourceId = (int)$request->request->get('sourceId');
         $source = Asset::getById($sourceId);
 
         $session = Tool\Session::getSessionBag($request->getSession(), 'opendxp_copy');
-        $sessionBag = $session->get($request->get('transactionId'));
+        $sessionBag = $session->get($request->request->get('transactionId'));
 
-        $targetId = (int)$request->get('targetId');
-        if ($request->get('targetParentId')) {
-            $sourceParent = Asset::getById((int) $request->get('sourceParentId'));
+        $targetId = (int)$request->request->get('targetId');
+        if ($request->request->has('targetParentId')) {
+            $sourceParent = Asset::getById((int) $request->request->get('sourceParentId'));
 
             // this is because the key can get the prefix "_copy" if the target does already exists
             if ($sessionBag['parentId']) {
                 $targetParent = Asset::getById((int) $sessionBag['parentId']);
             } else {
-                $targetParent = Asset::getById((int) $request->get('targetParentId'));
+                $targetParent = Asset::getById((int) $request->request->get('targetParentId'));
             }
 
             $targetPath = preg_replace('@^' . $sourceParent->getRealFullPath() . '@', $targetParent . '/', $source->getRealPath());
@@ -1824,19 +1832,19 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         if ($target->isAllowed('create')) {
             $source = Asset::getById($sourceId);
-            if ($source != null) {
-                if ($request->get('type') == 'child') {
+            if ($source !== null) {
+                if ($request->request->get('type') === 'child') {
                     $newAsset = $this->_assetService->copyAsChild($target, $source);
 
                     // this is because the key can get the prefix "_copy" if the target does already exists
-                    if ($request->get('saveParentId')) {
+                    if ($request->request->get('saveParentId')) {
                         $sessionBag['parentId'] = $newAsset->getId();
                     }
-                } elseif ($request->get('type') == 'replace') {
+                } elseif ($request->request->get('type') === 'replace') {
                     $this->_assetService->copyContents($target, $source);
                 }
 
-                $session->set($request->get('transactionId'), $sessionBag);
+                $session->set($request->request->get('transactionId'), $sessionBag);
 
                 $success = true;
             } else {
@@ -1854,10 +1862,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/download-as-zip-jobs', name: 'opendxp_admin_asset_downloadaszipjobs', methods: ['GET'])]
     public function downloadAsZipJobsAction(Request $request): JsonResponse
     {
-        $jobId = uniqid();
+        $jobId = uniqid('', false);
         $filesPerJob = 5;
         $jobs = [];
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
 
         if (!$asset) {
             throw $this->createNotFoundException('Asset not found');
@@ -1871,7 +1879,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             $db = \OpenDxp\Db::get();
             $conditionFilters = [];
-            $selectedIds = explode(',', $request->get('selectedIds', ''));
+            $selectedIds = explode(',', $request->query->get('selectedIds', ''));
             $quotedSelectedIds = [];
             foreach ($selectedIds as $selectedId) {
                 if ($selectedId) {
@@ -1925,8 +1933,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/download-as-zip-add-files', name: 'opendxp_admin_asset_downloadaszipaddfiles', methods: ['GET'])]
     public function downloadAsZipAddFilesAction(Request $request): JsonResponse
     {
-        $zipFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/download-zip-' . $request->get('jobId') . '.zip';
-        $asset = Asset::getById((int) $request->get('id'));
+        $zipFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/download-zip-' . $request->query->get('jobId') . '.zip';
+        $asset = Asset::getById((int) $request->query->get('id'));
         $success = false;
 
         if (!$asset) {
@@ -1939,14 +1947,14 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
             if ($zipState === true) {
                 $parentPath = $asset->getRealFullPath();
-                if ($asset->getId() == 1) {
+                if ($asset->getId() === 1) {
                     $parentPath = '';
                 }
 
                 $db = \OpenDxp\Db::get();
                 $conditionFilters = [];
 
-                $selectedIds = $request->get('selectedIds', []);
+                $selectedIds = $request->query->get('selectedIds', []);
 
                 if (!empty($selectedIds)) {
                     $selectedIds = explode(',', $selectedIds);
@@ -1975,8 +1983,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                 $assetList = new Asset\Listing();
                 $assetList->setCondition($condition);
                 $assetList->setOrderKey('LENGTH(`path`) ASC, id ASC', false);
-                $assetList->setOffset((int)$request->get('offset'));
-                $assetList->setLimit((int)$request->get('limit'));
+                $assetList->setOffset((int)$request->query->get('offset'));
+                $assetList->setLimit((int)$request->query->get('limit'));
 
                 foreach ($assetList as $a) {
                     if (!$a->isAllowed('view')) {
@@ -2006,11 +2014,11 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/download-as-zip', name: 'opendxp_admin_asset_downloadaszip', methods: ['GET'])]
     public function downloadAsZipAction(Request $request): BinaryFileResponse
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
         if (!$asset) {
             throw $this->createNotFoundException('Asset not found');
         }
-        $zipFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/download-zip-' . $request->get('jobId') . '.zip';
+        $zipFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/download-zip-' . $request->query->get('jobId') . '.zip';
         $suggestedFilename = $asset->getFilename();
         if (empty($suggestedFilename)) {
             $suggestedFilename = 'assets';
@@ -2027,12 +2035,19 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/import-zip', name: 'opendxp_admin_asset_importzip', methods: ['POST'])]
     public function importZipAction(Request $request, TranslatorInterface $translator): Response
     {
-        $jobId = uniqid();
+        $jobId = uniqid('', false);
         $filesPerJob = 5;
         $jobs = [];
-        $asset = Asset::getById((int) $request->get('parentId'));
+        $asset = Asset::getById((int) $request->query->get('parentId'));
 
-        if (!is_file($_FILES['Filedata']['tmp_name'])) {
+        $filePath = null;
+        if($request->files->has('Filedata')) {
+            /** @var UploadedFile $file */
+            $file = $request->files->get('Filedata');
+            $filePath = $file->getPathname();
+        }
+
+        if ($filePath === null || !is_file($filePath)) {
             return $this->adminJson([
                 'success' => false,
                 'message' => 'Something went wrong, please check upload_max_filesize and post_max_size in your php.ini as well as the write permissions on the file system',
@@ -2049,7 +2064,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $zipFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/' . $jobId . '.zip';
 
-        copy($_FILES['Filedata']['tmp_name'], $zipFile);
+        copy($filePath, $zipFile);
 
         $zip = new ZipArchive;
         $retCode = $zip->open($zipFile);
@@ -2065,7 +2080,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                         'limit' => $filesPerJob,
                         'jobId' => $jobId,
                         'last' => (($i + 1) >= $jobAmount) ? 'true' : '',
-                        'allowOverwrite' => $request->get('allowOverwrite') ?: 'false',
+                        'allowOverwrite' => $request->query->get('allowOverwrite') ?: 'false',
                     ],
                 ]];
             }
@@ -2092,10 +2107,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/import-zip-files', name: 'opendxp_admin_asset_importzipfiles', methods: ['POST'])]
     public function importZipFilesAction(Request $request, Filesystem $filesystem): JsonResponse
     {
-        $jobId = $request->get('jobId');
-        $limit = (int)$request->get('limit');
-        $offset = (int)$request->get('offset');
-        $importAsset = Asset::getById((int) $request->get('parentId'));
+        $jobId = $request->request->get('jobId');
+        $limit = (int)$request->request->get('limit');
+        $offset = (int)$request->request->get('offset');
+        $importAsset = Asset::getById((int) $request->request->get('parentId'));
         $zipFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/' . $jobId . '.zip';
         $tmpDir = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/zip-import';
 
@@ -2127,11 +2142,12 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     $parentPath = $importAsset->getRealFullPath() . '/' . preg_replace('@^/@', '', $relativePath);
                     $parent = Asset\Service::createFolderByPath($parentPath);
                     // check for duplicate filename
-                    if ($request->get('allowOverwrite') && $request->get('allowOverwrite') !== 'true') {
+                    if ($request->request->has('allowOverwrite') && $request->request->get('allowOverwrite') !== 'true') {
                         $filename = $this->getSafeFilename($parent->getRealFullPath(), $filename);
                     }
+
                     if ($parent->isAllowed('create')) {
-                        if ($request->get('allowOverwrite') && $request->get('allowOverwrite') === 'true'
+                        if ($request->request->has('allowOverwrite') && $request->request->get('allowOverwrite') === 'true'
                             && Asset\Service::pathExists($parent->getRealFullPath().'/'.$filename)) {
                             $asset = Asset::getByPath($parent->getRealFullPath().'/'.$filename);
                             $asset->setStream(fopen($tmpFile, 'rb', false, File::getContext()));
@@ -2154,7 +2170,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             $zip->close();
         }
 
-        if ($request->get('last')) {
+        if ($request->request->get('last')) {
             unlink($zipFile);
         }
 
@@ -2168,7 +2184,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     {
         $success = false;
 
-        if ($asset = Asset::getById((int) $request->get('id'))) {
+        if ($asset = Asset::getById((int) $request->request->get('id'))) {
             if (!$asset->isAllowed('publish')) {
                 throw $this->createAccessDeniedException('not allowed to publish');
             }
@@ -2190,7 +2206,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $filterPrepareEvent = new GenericEvent($this, [
             'requestParams' => $allParams,
         ]);
-        $language = $request->get('language') != 'default' ? $request->get('language') : null;
+        $language = $request->query->get('language') !== 'default' ? $request->query->get('language') : null;
 
         $eventDispatcher->dispatch($filterPrepareEvent, AdminEvents::ASSET_LIST_BEFORE_FILTER_PREPARE);
 
@@ -2200,7 +2216,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         if (isset($allParams['data']) && $allParams['data']) {
             $csrfProtection->checkCsrfToken($request);
-            if ($allParams['xaction'] == 'update') {
+            if ($allParams['xaction'] === 'update') {
                 try {
                     $data = $this->decodeJson($allParams['data']);
 
@@ -2239,7 +2255,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                         $fieldDef = explode('~', $key);
                         $key = $fieldDef[0];
                         if (isset($fieldDef[1])) {
-                            $language = ($fieldDef[1] == 'none' ? '' : $fieldDef[1]);
+                            $language = ($fieldDef[1] === 'none' ? '' : $fieldDef[1]);
                         }
 
                         foreach ($metadata as &$em) {
@@ -2362,7 +2378,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     #[Route('/get-text', name: 'opendxp_admin_asset_gettext', methods: ['GET'])]
     public function getTextAction(Request $request): JsonResponse
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
 
         if (!$asset) {
             throw $this->createNotFoundException('Asset not found');
@@ -2372,7 +2388,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             throw $this->createAccessDeniedException('not allowed to view');
         }
 
-        $page = $request->get('page');
+        $page = $request->query->get('page');
         $text = null;
         if ($asset instanceof Asset\Document) {
             $text = $asset->getText($page);

--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -919,10 +919,10 @@ class AssetHelperController extends AdminAbstractController
     public function batchAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         try {
-            if ($request->get('data')) {
+            if ($request->request->has('data')) {
                 $loader = OpenDxp::getContainer()->get('opendxp.implementation_loader.asset.metadata.data');
 
-                $data = $this->decodeJson($request->get('data'), true);
+                $data = $this->decodeJson($request->request->get('data'), true);
 
                 $updateEvent = new GenericEvent($this, [
                     'data' => $data,
@@ -939,7 +939,7 @@ class AssetHelperController extends AdminAbstractController
 
                 $language = null;
                 if (isset($data['language'])) {
-                    $language = $data['language'] != 'default' ? $data['language'] : null;
+                    $language = $data['language'] !== 'default' ? $data['language'] : null;
                 }
 
                 $asset = Asset::getById((int) $data['job']);
@@ -955,14 +955,14 @@ class AssetHelperController extends AdminAbstractController
                     $name = $data['name'];
                     $value = $data['value'];
 
-                    if ($data['valueType'] == 'object') {
+                    if ($data['valueType'] === 'object') {
                         $value = $this->decodeJson($value);
                     }
 
                     $fieldDef = explode('~', $name);
                     $name = $fieldDef[0];
                     if (count($fieldDef) > 1) {
-                        $language = ($fieldDef[1] == 'none' ? '' : $fieldDef[1]);
+                        $language = ($fieldDef[1] === 'none' ? '' : $fieldDef[1]);
                     }
 
                     foreach ($metadata as &$em) {

--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -126,7 +126,7 @@ class AssetHelperController extends AdminAbstractController
     {
         $params = [
             'id'              => $request->request->get('id'),
-            'type'            => $request->query->get('type'),
+            'type'            => $request->request->get('type'),
             'types'           => $request->request->get('types'),
             'gridConfigId'    => $request->request->get('gridConfigId'),
             'searchType'      => $request->request->get('searchType'),

--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -124,7 +124,16 @@ class AssetHelperController extends AdminAbstractController
     #[Route('/grid-delete-column-config', name: 'opendxp_admin_asset_assethelper_griddeletecolumnconfig', methods: ['DELETE'])]
     public function gridDeleteColumnConfigAction(Request $request): JsonResponse
     {
-        $gridConfigId = (int) $request->get('gridConfigId');
+        $params = [
+            'id'              => $request->request->get('id'),
+            'type'            => $request->query->get('type'),
+            'types'           => $request->request->get('types'),
+            'gridConfigId'    => $request->request->get('gridConfigId'),
+            'searchType'      => $request->request->get('searchType'),
+            'noSystemColumns' => $request->query->getBoolean('no_system_columns'),
+        ];
+
+        $gridConfigId = (int) $request->request->get('gridConfigId');
         $gridConfig = GridConfig::getById($gridConfigId);
         $success = false;
         if ($gridConfig) {
@@ -136,7 +145,7 @@ class AssetHelperController extends AdminAbstractController
             $success = true;
         }
 
-        $newGridConfig = $this->doGetGridColumnConfig($request, true);
+        $newGridConfig = $this->doGetGridColumnConfig($params, true);
         $newGridConfig['deleteSuccess'] = $success;
 
         return $this->adminJson($newGridConfig);
@@ -145,31 +154,39 @@ class AssetHelperController extends AdminAbstractController
     #[Route('/grid-get-column-config', name: 'opendxp_admin_asset_assethelper_gridgetcolumnconfig', methods: ['GET'])]
     public function gridGetColumnConfigAction(Request $request): JsonResponse
     {
-        $result = $this->doGetGridColumnConfig($request);
+        $params = [
+            'id'              => $request->query->get('id'),
+            'type'            => $request->query->get('type'),
+            'types'           => $request->query->get('types'),
+            'gridConfigId'    => $request->query->get('gridConfigId'),
+            'searchType'      => $request->query->get('searchType'),
+            'noSystemColumns' => $request->query->getBoolean('no_system_columns'),
+        ];
+
+        $result = $this->doGetGridColumnConfig($params);
 
         return $this->adminJson($result);
     }
 
-    public function doGetGridColumnConfig(Request $request, bool $isDelete = false): array
+    private function doGetGridColumnConfig(array $params, bool $isDelete = false): array
     {
         $gridConfigId = null;
 
-        $classId = $request->get('id');
-
+        $classId = $params['id'];
         $context = ['purpose' => 'gridconfig'];
 
         $types = [];
-        if ($request->get('types')) {
-            $types = explode(',', $request->get('types'));
+        if (!empty($params['types'])) {
+            $types = explode(',', $params['types']);
         }
 
         $userId = $this->getAdminUser()->getId();
 
-        $requestedGridConfigId = $isDelete ? '' : $request->get('gridConfigId', '');
+        $requestedGridConfigId = $isDelete ? '' : $params['gridConfigId'] ?? '';
 
         // grid config
         $gridConfig = [];
-        $searchType = $request->get('searchType');
+        $searchType = $params['searchType'];
 
         if ((string) $requestedGridConfigId === '') {
             // check if there is a favourite view
@@ -214,7 +231,7 @@ class AssetHelperController extends AdminAbstractController
 
         if (empty($gridConfig)) {
             $availableFields = $this->getDefaultGridFields(
-                $request->query->getBoolean('no_system_columns'),
+                $params['noSystemColumns'],
                 [], //maybe required for types other than metadata
                 $context,
                 $types
@@ -231,7 +248,7 @@ class AssetHelperController extends AdminAbstractController
                 }
             }
         }
-        usort($availableFields, fn ($a, $b) => $a['position'] <=> $b['position']);
+        usort($availableFields, static fn ($a, $b) => $a['position'] <=> $b['position']);
 
         $availableConfigs = $classId ? $this->getMyOwnGridColumnConfigs($userId, $classId, $searchType) : [];
         $sharedConfigs = $classId ? $this->getSharedGridColumnConfigs($this->getAdminUser(), $classId, $searchType) : [];
@@ -347,11 +364,12 @@ class AssetHelperController extends AdminAbstractController
     {
         $helperColumns = [];
         $newData = [];
-        $data = json_decode($request->get('columns'));
+        $data = json_decode($request->request->get('columns'));
+
         /** @var stdClass $item */
         foreach ($data as $item) {
             if (!empty($item->isOperator)) {
-                $itemKey = '#' . uniqid();
+                $itemKey = '#' . uniqid('', false);
 
                 $item->key = $itemKey;
                 $newData[] = $item;
@@ -361,7 +379,7 @@ class AssetHelperController extends AdminAbstractController
             }
         }
 
-        Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($helperColumns): void {
+        Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($helperColumns): void {
             $existingColumns = $session->get('helpercolumns', []);
             $helperColumns = [...$helperColumns, ...$existingColumns];
             $session->set('helpercolumns', $helperColumns);
@@ -373,13 +391,13 @@ class AssetHelperController extends AdminAbstractController
     #[Route('/grid-mark-favourite-column-config', name: 'opendxp_admin_asset_assethelper_gridmarkfavouritecolumnconfig', methods: ['POST'])]
     public function gridMarkFavouriteColumnConfigAction(Request $request): JsonResponse
     {
-        $classId = $request->get('classId');
+        $classId = $request->request->get('classId');
         $asset = Asset::getById(is_numeric($classId) ? (int) $classId : 0);
 
         if ($asset->isAllowed('list')) {
-            $gridConfigId = (int) $request->get('gridConfigId');
-            $searchType = $request->get('searchType');
-            $type = $request->get('type');
+            $gridConfigId = (int) $request->request->get('gridConfigId');
+            $searchType = $request->request->get('searchType');
+            $type = $request->request->get('type');
             $user = $this->getAdminUser();
 
             $favourite = new GridConfigFavourite();
@@ -387,7 +405,6 @@ class AssetHelperController extends AdminAbstractController
             $favourite->setClassId($classId);
             $favourite->setSearchType($searchType);
             $favourite->setType($type);
-            $specializedConfigs = false;
 
             try {
                 if ($gridConfigId !== 0) {
@@ -401,7 +418,7 @@ class AssetHelperController extends AdminAbstractController
                 $favourite->delete();
             }
 
-            return $this->adminJson(['success' => true, 'spezializedConfigs' => $specializedConfigs]);
+            return $this->adminJson(['success' => true, 'specializedConfigs' => false]);
         }
 
         throw $this->createAccessDeniedHttpException();
@@ -435,7 +452,7 @@ class AssetHelperController extends AdminAbstractController
     #[Route('/grid-save-column-config', name: 'opendxp_admin_asset_assethelper_gridsavecolumnconfig', methods: ['POST'])]
     public function gridSaveColumnConfigAction(Request $request): JsonResponse
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->request->get('id'));
 
         if (!$asset) {
             throw $this->createNotFoundException();
@@ -443,20 +460,20 @@ class AssetHelperController extends AdminAbstractController
 
         if ($asset->isAllowed('list')) {
             try {
-                $classId = $request->get('class_id');
-                $context = $request->get('context');
+                $classId = $request->request->get('class_id');
+                $context = $request->request->get('context');
 
-                $searchType = $request->get('searchType');
-                $type = $request->get('type');
+                $searchType = $request->request->get('searchType');
+                $type = $request->request->get('type');
 
                 // grid config
-                $gridConfigData = $this->decodeJson($request->get('gridconfig'));
+                $gridConfigData = $this->decodeJson($request->request->get('gridconfig'));
                 $gridConfigData['opendxp_version'] = Version::getVersion();
                 $gridConfigData['opendxp_revision'] = Version::getRevision();
                 $gridConfigData['context'] = $context;
                 unset($gridConfigData['settings']['isShared']);
 
-                $metadata = $request->get('settings');
+                $metadata = $request->request->get('settings');
                 $metadata = json_decode($metadata, true);
 
                 $gridConfigId = $metadata['gridConfigId'];
@@ -644,7 +661,7 @@ class AssetHelperController extends AdminAbstractController
 
         $jobs = array_chunk($ids, 20);
 
-        $fileHandle = uniqid('asset-export-');
+        $fileHandle = uniqid('asset-export-', false);
         $storage = Storage::get('temp');
         $storage->write($this->getCsvFile($fileHandle), '');
 
@@ -657,11 +674,11 @@ class AssetHelperController extends AdminAbstractController
     #[Route('/do-export', name: 'opendxp_admin_asset_assethelper_doexport', methods: ['POST'])]
     public function doExportAction(Request $request): JsonResponse
     {
-        $fileHandle = File::getValidFilename($request->get('fileHandle'));
-        $ids = $request->get('ids');
-        $settings = json_decode($request->get('settings'), true);
+        $fileHandle = File::getValidFilename($request->request->get('fileHandle'));
+        $ids = $request->request->all('ids');
+        $settings = json_decode($request->request->get('settings'), true);
         $delimiter = $settings['delimiter'] ?? ';';
-        $language = str_replace('default', '', $request->get('language'));
+        $language = str_replace('default', '', $request->request->get('language'));
         $header = $settings['header'] ?? 'title';
 
         $list = new Asset\Listing();
@@ -674,9 +691,9 @@ class AssetHelperController extends AdminAbstractController
         $list->setCondition('id IN (' . implode(',', $quotedIds) . ')');
         $list->setOrderKey(' FIELD(id, ' . implode(',', $quotedIds) . ')', false);
 
-        $fields = json_decode($request->get('fields')[0], true);
+        $fields = json_decode($request->request->all('fields')[0], true);
 
-        $addTitles = (bool) $request->get('initial');
+        $addTitles = (bool) $request->request->get('initial');
 
         $csv = $this->getCsvData($language, $list, $fields, $header, $addTitles);
 
@@ -691,7 +708,7 @@ class AssetHelperController extends AdminAbstractController
             stream_copy_to_stream($fileStream, $temp, null, 0);
 
             $firstLine = true;
-            if ($request->get('initial') && $header === 'no_header') {
+            if ($request->request->get('initial') && $header === 'no_header') {
                 $firstLine = false;
             }
 
@@ -764,7 +781,7 @@ class AssetHelperController extends AdminAbstractController
                     $getter = 'get' . ucfirst($fieldDef[0]);
 
                     if (isset($fieldDef[1])) {
-                        if ($fieldDef[1] == 'system' && method_exists($asset, $getter)) {
+                        if ($fieldDef[1] === 'system' && method_exists($asset, $getter)) {
                             $data = $asset->$getter($language);
                         } else {
                             $fieldDef[1] = str_replace('none', '', $fieldDef[1]);
@@ -787,20 +804,6 @@ class AssetHelperController extends AdminAbstractController
         return $csv;
     }
 
-    protected function extractLanguage(Request $request): string
-    {
-        $requestedLanguage = $request->get('language');
-        if ($requestedLanguage) {
-            if ($requestedLanguage != 'default') {
-                $request->setLocale($requestedLanguage);
-            }
-        } else {
-            $requestedLanguage = $request->getLocale();
-        }
-
-        return $requestedLanguage;
-    }
-
     protected function getCsvFile(string $fileHandle): string
     {
         return $fileHandle . '.csv';
@@ -810,7 +813,7 @@ class AssetHelperController extends AdminAbstractController
     public function downloadCsvFileAction(Request $request): Response
     {
         $storage = Storage::get('temp');
-        $fileHandle = File::getValidFilename($request->get('fileHandle'));
+        $fileHandle = File::getValidFilename($request->query->get('fileHandle'));
         $csvFile = $this->getCsvFile($fileHandle);
 
         try {
@@ -836,7 +839,7 @@ class AssetHelperController extends AdminAbstractController
     public function downloadXlsxFileAction(Request $request, GridHelperService $gridHelperService): BinaryFileResponse
     {
         $storage = Storage::get('temp');
-        $fileHandle = File::getValidFilename($request->get('fileHandle'));
+        $fileHandle = File::getValidFilename($request->query->get('fileHandle'));
         $csvFile = $this->getCsvFile($fileHandle);
 
         try {
@@ -903,8 +906,8 @@ class AssetHelperController extends AdminAbstractController
     #[Route('/get-batch-jobs', name: 'opendxp_admin_asset_assethelper_getbatchjobs', methods: ['POST'])]
     public function getBatchJobsAction(Request $request, GridHelperService $gridHelperService): JsonResponse
     {
-        if ($request->get('language')) {
-            $request->setLocale($request->get('language'));
+        if ($request->request->get('language')) {
+            $request->setLocale($request->request->get('language'));
         }
 
         $allParams = [...$request->request->all(), ...$request->query->all()];
@@ -1030,9 +1033,9 @@ class AssetHelperController extends AdminAbstractController
                                 'id' => $asset->getId(),
                                 'metadata' => $metadata,
                             ]);
+
                             $eventDispatcher->dispatch($metadataEvent, AdminEvents::ASSET_METADATA_PRE_SET);
 
-                            // $metadata = Asset\Service::minimizeMetadata($metadata, "grid");
                             $asset->setMetadataRaw($metadata);
                             $asset->save();
 

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -30,6 +30,7 @@ use OpenDxp\Model\Exception\ConfigWriteException;
 use OpenDxp\Model\Translation;
 use OpenDxp\Tool\Session;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -96,7 +97,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $classes = $classesList->load();
 
         // filter classes
-        if ($request->get('createAllowed')) {
+        if ($request->query->get('createAllowed')) {
             $tmpClasses = [];
             foreach ($classes as $class) {
                 if ($this->getAdminUser()->isAllowed($class->getId(), 'class')) {
@@ -106,9 +107,9 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $classes = $tmpClasses;
         }
 
-        $withId = $request->get('withId');
-        $useTitle = $request->get('useTitle');
-        $getClassConfig = function ($class) use ($defaultIcon, $withId, $useTitle) {
+        $withId = $request->query->get('withId');
+        $useTitle = $request->query->get('useTitle');
+        $getClassConfig = static function ($class) use ($defaultIcon, $withId, $useTitle) {
             $text = $class->getName();
             if ($useTitle) {
                 $text = $class->getTitle() ?: $class->getName();
@@ -175,12 +176,12 @@ class ClassController extends AdminAbstractController implements KernelControlle
             array_multisort($types, SORT_ASC, array_keys($groups), SORT_ASC, $groups);
         }
 
-        if (!$request->get('grouped')) {
+        if (!$request->query->get('grouped')) {
             // list output
             foreach ($groups as $groupName => $groupData) {
                 foreach ($groupData['classes'] as $class) {
                     $node = $getClassConfig($class);
-                    if (count($groupData['classes']) > 1 || $groupData['type'] == 'manual') {
+                    if (count($groupData['classes']) > 1 || $groupData['type'] === 'manual') {
                         $node['group'] = $groupName;
                     }
                     $treeNodes[] = $node;
@@ -189,7 +190,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         } else {
             // create json output
             foreach ($groups as $groupName => $groupData) {
-                if (count($groupData['classes']) === 1 && $groupData['type'] == 'auto') {
+                if (count($groupData['classes']) === 1 && $groupData['type'] === 'auto') {
                     // no group, only one child
                     $node = $getClassConfig($groupData['classes'][0]);
                 } else {
@@ -219,7 +220,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/get', name: 'get', methods: ['GET'])]
     public function getAction(Request $request): JsonResponse
     {
-        $class = DataObject\ClassDefinition::getById($request->get('id'));
+        $class = DataObject\ClassDefinition::getById($request->query->get('id'));
         if (!$class) {
             throw $this->createNotFoundException();
         }
@@ -234,21 +235,21 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/get-custom-layout', name: 'getcustomlayout', methods: ['GET'])]
     public function getCustomLayoutAction(Request $request): JsonResponse
     {
-        $customLayout = DataObject\ClassDefinition\CustomLayout::getById($request->get('id'));
+        $customLayout = DataObject\ClassDefinition\CustomLayout::getById($request->query->get('id'));
         if (!$customLayout) {
-            $brickLayoutSeparator = strpos($request->get('id'), '.brick.');
+            $brickLayoutSeparator = strpos($request->query->get('id'), '.brick.');
             if ($brickLayoutSeparator !== false) {
-                $customLayout = DataObject\ClassDefinition\CustomLayout::getById(substr($request->get('id'), 0, $brickLayoutSeparator));
+                $customLayout = DataObject\ClassDefinition\CustomLayout::getById(substr($request->query->get('id'), 0, $brickLayoutSeparator));
                 if ($customLayout instanceof DataObject\ClassDefinition\CustomLayout) {
                     $customLayout = DataObject\ClassDefinition\CustomLayout::create(
                         [
-                            'name' => $customLayout->getName().' '.substr($request->get('id'), $brickLayoutSeparator+strlen('.brick.')),
+                            'name' => $customLayout->getName().' '.substr($request->query->get('id'), $brickLayoutSeparator+strlen('.brick.')),
                             'userOwner' => $this->getAdminUser()->getId(),
                             'classId' => $customLayout->getClassId(),
                         ]
                     );
 
-                    $customLayout->setId($request->get('id'));
+                    $customLayout->setId($request->query->get('id'));
                     if (!$customLayout->isWriteable()) {
                         throw new ConfigWriteException();
                     }
@@ -270,10 +271,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/add', name: 'add', methods: ['POST'])]
     public function addAction(Request $request): JsonResponse
     {
-        $className = $request->get('className');
+        $className = $request->request->get('className');
         $className = $this->correctClassname($className);
 
-        $classId = $request->get('classIdentifier');
+        $classId = $request->request->get('classIdentifier');
         $existingClass = DataObject\ClassDefinition::getById($classId);
         if ($existingClass) {
             throw new Exception('Class identifier already exists');
@@ -294,17 +295,18 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/add-custom-layout', name: 'addcustomlayout', methods: ['POST'])]
     public function addCustomLayoutAction(Request $request): JsonResponse
     {
-        $layoutId = $request->get('layoutIdentifier');
+        $layoutId = $request->request->get('layoutIdentifier');
         $existingLayout = DataObject\ClassDefinition\CustomLayout::getById($layoutId);
+
         if ($existingLayout) {
             throw new Exception('Custom Layout identifier already exists');
         }
 
         $customLayout = DataObject\ClassDefinition\CustomLayout::create(
             [
-                'name' => $request->get('layoutName'),
+                'name' => $request->request->get('layoutName'),
                 'userOwner' => $this->getAdminUser()->getId(),
-                'classId' => $request->get('classId'),
+                'classId' => $request->request->get('classId'),
             ]
         );
 
@@ -312,20 +314,25 @@ class ClassController extends AdminAbstractController implements KernelControlle
         if (!$customLayout->isWriteable()) {
             throw new ConfigWriteException();
         }
+
         $customLayout->save();
 
         $isWriteable = $customLayout->isWriteable();
         $data = $customLayout->getObjectVars();
         $data['isWriteable'] = $isWriteable;
 
-        return $this->adminJson(['success' => true, 'id' => $customLayout->getId(), 'name' => $customLayout->getName(),
-                                 'data' => $data, ]);
+        return $this->adminJson([
+            'success' => true,
+            'id' => $customLayout->getId(),
+            'name' => $customLayout->getName(),
+            'data' => $data
+        ]);
     }
 
     #[Route('/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): Response
     {
-        $class = DataObject\ClassDefinition::getById($request->get('id'));
+        $class = DataObject\ClassDefinition::getById($request->request->get('id'));
         if ($class) {
             $class->delete();
         }
@@ -337,7 +344,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     public function deleteCustomLayoutAction(Request $request): JsonResponse
     {
         $customLayouts = new DataObject\ClassDefinition\CustomLayout\Listing();
-        $id = $request->get('id');
+        $id = $request->request->get('id');
         $customLayouts->setFilter(function (DataObject\ClassDefinition\CustomLayout $layout) use ($id) {
             $currentLayoutId = $layout->getId();
 
@@ -354,13 +361,13 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/save-custom-layout', name: 'savecustomlayout', methods: ['PUT'])]
     public function saveCustomLayoutAction(Request $request): JsonResponse
     {
-        $customLayout = DataObject\ClassDefinition\CustomLayout::getById($request->get('id'));
+        $customLayout = DataObject\ClassDefinition\CustomLayout::getById($request->request->get('id'));
         if (!$customLayout) {
             throw $this->createNotFoundException();
         }
 
-        $configuration = $this->decodeJson($request->get('configuration'));
-        $values = $this->decodeJson($request->get('values'));
+        $configuration = $this->decodeJson($request->request->get('configuration'));
+        $values = $this->decodeJson($request->request->get('values'));
 
         $modificationDate = (int)$values['modificationDate'];
         if ($modificationDate < $customLayout->getModificationDate()) {
@@ -396,13 +403,13 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/save', name: 'save', methods: ['PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $class = DataObject\ClassDefinition::getById($request->get('id'));
+        $class = DataObject\ClassDefinition::getById($request->request->get('id'));
         if (!$class) {
             throw $this->createNotFoundException();
         }
 
-        $configuration = $this->decodeJson($request->get('configuration'));
-        $values = $this->decodeJson($request->get('values'));
+        $configuration = $this->decodeJson($request->request->get('configuration'));
+        $values = $this->decodeJson($request->request->get('values'));
 
         // check if the class was changed during editing in the frontend
         if ($class->getModificationDate() != $values['modificationDate']) {
@@ -427,10 +434,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
             }
         }
 
-        unset($values['creationDate']);
-        unset($values['userOwner']);
-        unset($values['layoutDefinitions']);
-        unset($values['fieldDefinitions']);
+        unset($values['creationDate'], $values['userOwner'], $values['layoutDefinitions'], $values['fieldDefinitions']);
 
         $configuration['datatype'] = 'layout';
         $configuration['fieldtype'] = 'panel';
@@ -448,7 +452,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
             $propertyVisibility = [];
             foreach ($values as $key => $value) {
-                if (preg_match('/propertyVisibility/i', $key)) {
+                if (false !== stripos($key, 'propertyVisibility')) {
                     if (preg_match("/\.grid\./i", $key)) {
                         $propertyVisibility['grid'][preg_replace("/propertyVisibility\.grid\./i", '', $key)] = (bool) $value;
                     } elseif (preg_match("/\.search\./i", $key)) {
@@ -483,17 +487,21 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/import-class', name: 'importclass', methods: ['POST', 'PUT'])]
     public function importClassAction(Request $request): Response
     {
-        $class = DataObject\ClassDefinition::getById($request->get('id'));
+        $class = DataObject\ClassDefinition::getById($request->query->get('id'));
         if (!$class) {
             throw $this->createNotFoundException();
         }
-        $json = file_get_contents($_FILES['Filedata']['tmp_name']);
+
+        /** @var UploadedFile $file */
+        $file = $request->files->get('Filedata');
+        $json = file_get_contents($file->getPathname());
 
         $success = DataObject\ClassDefinition\Service::importClassDefinitionFromJson($class, $json, false, true);
 
         $response = $this->adminJson([
             'success' => $success,
         ]);
+
         // set content-type to text/html, otherwise (when application/json is sent) chrome will complain in
         // Ext.form.Action.Submit and mark the submission as failed
         $response->headers->set('Content-Type', 'text/html');
@@ -506,7 +514,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $success = false;
         $responseContent = [];
-        $json = file_get_contents($_FILES['Filedata']['tmp_name']);
+
+        /** @var UploadedFile $file */
+        $file = $request->files->get('Filedata');
+        $json = file_get_contents($file->getPathname());
+
         $importData = $this->decodeJson($json);
 
         $existingLayout = null;
@@ -519,7 +531,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         }
 
         if (!$existingLayout instanceof DataObject\ClassDefinition\CustomLayout) {
-            $customLayoutId = $request->get('id');
+            $customLayoutId = $request->query->get('id');
             $customLayout = DataObject\ClassDefinition\CustomLayout::getById($customLayoutId);
             if ($customLayout) {
                 try {
@@ -554,7 +566,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/get-custom-layout-definitions', name: 'getcustomlayoutdefinitions', methods: ['GET'])]
     public function getCustomLayoutDefinitionsAction(Request $request): JsonResponse
     {
-        $classIds = explode(',', $request->get('classId'));
+        $classIds = explode(',', $request->query->get('classId'));
         $list = new DataObject\ClassDefinition\CustomLayout\Listing();
 
         $list->setFilter(fn (DataObject\ClassDefinition\CustomLayout $layout) => in_array($layout->getClassId(), $classIds) && !str_contains($layout->getId(), '.brick.'));
@@ -617,7 +629,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/export-class', name: 'exportclass', methods: ['GET'])]
     public function exportClassAction(Request $request): Response
     {
-        $id = $request->get('id');
+        $id = $request->query->get('id');
         $class = DataObject\ClassDefinition::getById($id);
 
         if (!$class instanceof DataObject\ClassDefinition) {
@@ -639,7 +651,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/export-custom-layout-definition', name: 'exportcustomlayoutdefinition', methods: ['GET'])]
     public function exportCustomLayoutDefinitionAction(Request $request): Response
     {
-        $id = $request->get('id');
+        $id = $request->query->get('id');
 
         if ($id) {
             $customLayout = DataObject\ClassDefinition\CustomLayout::getById($id);
@@ -667,7 +679,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/fieldcollection-get', name: 'fieldcollectionget', methods: ['GET'])]
     public function fieldcollectionGetAction(Request $request): JsonResponse
     {
-        $fc = DataObject\Fieldcollection\Definition::getByKey($request->get('id'));
+        $fc = DataObject\Fieldcollection\Definition::getByKey($request->query->get('id'));
 
         $isWriteable = $fc->isWritable();
         $fc = $fc->getObjectVars();
@@ -680,11 +692,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
     public function fieldcollectionUpdateAction(Request $request): JsonResponse
     {
         try {
-            $key = $request->get('key');
-            $title = $request->get('title');
-            $group = $request->get('group');
+            $key = $request->request->get('key');
+            $title = $request->request->get('title');
+            $group = $request->request->get('group');
 
-            if ($request->get('task') == 'add') {
+            if ($request->request->get('task') === 'add') {
                 // check for existing fieldcollection with same name with different lower/upper cases
                 $list = new DataObject\Fieldcollection\Definition\Listing();
                 $list = $list->loadNames();
@@ -701,14 +713,14 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $fcDef->setTitle($title);
             $fcDef->setGroup($group);
 
-            if ($request->get('values')) {
-                $values = $this->decodeJson($request->get('values'));
+            if ($request->request->has('values')) {
+                $values = $this->decodeJson($request->request->get('values'));
                 $fcDef->setParentClass($values['parentClass']);
                 $fcDef->setImplementsInterfaces($values['implementsInterfaces']);
             }
 
-            if ($request->get('configuration')) {
-                $configuration = $this->decodeJson($request->get('configuration'));
+            if ($request->request->has('configuration')) {
+                $configuration = $this->decodeJson($request->request->get('configuration'));
 
                 $configuration['datatype'] = 'layout';
                 $configuration['fieldtype'] = 'panel';
@@ -732,9 +744,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $this->checkPermission('fieldcollections');
 
-        $fieldCollection = DataObject\Fieldcollection\Definition::getByKey($request->get('id'));
+        $fieldCollection = DataObject\Fieldcollection\Definition::getByKey($request->query->get('id'));
 
-        $data = file_get_contents($_FILES['Filedata']['tmp_name']);
+        /** @var UploadedFile $file */
+        $file = $request->files->get('Filedata');
+        $data = file_get_contents($file->getPathname());
 
         $success = DataObject\ClassDefinition\Service::importFieldCollectionFromJson($fieldCollection, $data);
 
@@ -754,10 +768,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $this->checkPermission('fieldcollections');
 
-        $fieldCollection = DataObject\Fieldcollection\Definition::getByKey($request->get('id'));
+        $fieldCollection = DataObject\Fieldcollection\Definition::getByKey($request->query->get('id'));
 
         if (!$fieldCollection instanceof DataObject\Fieldcollection\Definition) {
-            $errorMessage = ': Field-Collection with id [ ' . $request->get('id') . ' not found. ]';
+            $errorMessage = ': Field-Collection with id [ ' . $request->query->get('id') . ' not found. ]';
             Logger::error($errorMessage);
 
             throw $this->createNotFoundException($errorMessage);
@@ -776,7 +790,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $this->checkPermission('fieldcollections');
 
-        $fc = DataObject\Fieldcollection\Definition::getByKey($request->get('id'));
+        $fc = DataObject\Fieldcollection\Definition::getByKey($request->request->get('id'));
         $fc->delete();
 
         return $this->adminJson(['success' => true]);
@@ -788,7 +802,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $list = new DataObject\Fieldcollection\Definition\Listing();
         $list = $list->load();
 
-        $forObjectEditor = $request->get('forObjectEditor');
+        $forObjectEditor = $request->query->get('forObjectEditor');
 
         $layoutDefinitions = [];
 
@@ -796,11 +810,14 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
         $allowedTypes = null;
         if ($request->query->has('allowedTypes')) {
-            $allowedTypes = explode(',', $request->get('allowedTypes'));
+            $allowedTypes = explode(',', $request->query->get('allowedTypes'));
         }
-        $object = DataObject\Concrete::getById((int) $request->get('object_id'));
 
-        $currentLayoutId = $request->get('layoutId');
+        $object = $request->query->has('object_id')
+            ? DataObject\Concrete::getById((int) $request->query->get('object_id'))
+            : null;
+
+        $currentLayoutId = $request->query->get('layoutId');
         $user = \OpenDxp\Tool\Admin::getCurrentUser();
 
         $groups = [];
@@ -868,7 +885,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
         $event = new GenericEvent($this, [
             'list' => $definitions,
-            'objectId' => $request->get('object_id'),
+            'objectId' => $request->query->get('object_id'),
             'layoutDefinitions' => $layoutDefinitions,
         ]);
         $eventDispatcher->dispatch($event, AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA);
@@ -886,14 +903,14 @@ class ClassController extends AdminAbstractController implements KernelControlle
     public function fieldcollectionListAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $user = \OpenDxp\Tool\Admin::getCurrentUser();
-        $currentLayoutId = $request->get('layoutId');
+        $currentLayoutId = $request->query->get('layoutId');
 
         $list = new DataObject\Fieldcollection\Definition\Listing();
         $list = $list->load();
 
         if ($request->query->has('allowedTypes')) {
             $filteredList = [];
-            $allowedTypes = explode(',', $request->get('allowedTypes'));
+            $allowedTypes = explode(',', $request->query->get('allowedTypes'));
             foreach ($list as $type) {
                 if (in_array($type->getKey(), $allowedTypes)) {
                     $filteredList[] = $type;
@@ -903,10 +920,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
                     $context = [
                         'containerType' => 'fieldcollection',
                         'containerKey' => $type->getKey(),
-                        'outerFieldname' => $request->get('field_name'),
+                        'outerFieldname' => $request->query->get('field_name'),
                     ];
 
-                    $object = DataObject\Concrete::getById((int) $request->get('object_id'));
+                    $object = DataObject\Concrete::getById((int) $request->query->get('object_id'));
 
                     DataObject\Service::enrichLayoutDefinition($layoutDefinitions, $object, $context);
 
@@ -921,7 +938,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
         $event = new GenericEvent($this, [
             'list' => $list,
-            'objectId' => $request->get('object_id'),
+            'objectId' => $request->query->get('object_id'),
         ]);
         $eventDispatcher->dispatch($event, AdminEvents::CLASS_FIELDCOLLECTION_LIST_PRE_SEND_DATA);
         $list = $event->getArgument('list');
@@ -932,11 +949,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/get-class-definition-for-column-config', name: 'getclassdefinitionforcolumnconfig', methods: ['GET'])]
     public function getClassDefinitionForColumnConfigAction(Request $request): JsonResponse
     {
-        $class = DataObject\ClassDefinition::getById($request->get('id'));
+        $class = DataObject\ClassDefinition::getById($request->query->get('id'));
         if (!$class) {
             throw $this->createNotFoundException();
         }
-        $objectId = (int)$request->get('oid');
+        $objectId = (int)$request->query->get('oid');
 
         $filteredDefinitions = DataObject\Service::getCustomLayoutDefinitionForGridColumnConfig($class, $objectId);
 
@@ -1007,7 +1024,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/objectbrick-get', name: 'objectbrickget', methods: ['GET'])]
     public function objectbrickGetAction(Request $request): JsonResponse
     {
-        $fc = DataObject\Objectbrick\Definition::getByKey($request->get('id'));
+        $fc = DataObject\Objectbrick\Definition::getByKey($request->query->get('id'));
 
         $isWriteable = $fc->isWritable();
         $fc = $fc->getObjectVars();
@@ -1020,11 +1037,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
     public function objectbrickUpdateAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         try {
-            $key = $request->get('key');
-            $title = $request->get('title');
-            $group = $request->get('group');
+            $key = $request->request->get('key');
+            $title = $request->request->get('title');
+            $group = $request->request->get('group');
 
-            if ($request->get('task') == 'add') {
+            if ($request->request->get('task') === 'add') {
                 // check for existing brick with same name with different lower/upper cases
                 $list = new DataObject\Objectbrick\Definition\Listing();
                 $list = $list->loadNames();
@@ -1042,16 +1059,16 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $brickDef->setTitle($title);
             $brickDef->setGroup($group);
 
-            if ($request->get('values')) {
-                $values = $this->decodeJson($request->get('values'));
+            if ($request->request->has('values')) {
+                $values = $this->decodeJson($request->request->get('values'));
 
                 $brickDef->setParentClass($values['parentClass']);
                 $brickDef->setImplementsInterfaces($values['implementsInterfaces']);
                 $brickDef->setClassDefinitions($values['classDefinitions']);
             }
 
-            if ($request->get('configuration')) {
-                $configuration = $this->decodeJson($request->get('configuration'));
+            if ($request->request->has('configuration')) {
+                $configuration = $this->decodeJson($request->request->get('configuration'));
 
                 $configuration['datatype'] = 'layout';
                 $configuration['fieldtype'] = 'panel';
@@ -1063,6 +1080,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $event = new GenericEvent($this, [
                 'brickDefinition' => $brickDef,
             ]);
+
             $eventDispatcher->dispatch($event, AdminEvents::CLASS_OBJECTBRICK_UPDATE_DEFINITION);
             $brickDef = $event->getArgument('brickDefinition');
 
@@ -1081,9 +1099,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $this->checkPermission('objectbricks');
 
-        $objectBrick = DataObject\Objectbrick\Definition::getByKey($request->get('id'));
+        $objectBrick = DataObject\Objectbrick\Definition::getByKey($request->query->get('id'));
 
-        $data = file_get_contents($_FILES['Filedata']['tmp_name']);
+        /** @var UploadedFile $file */
+        $file = $request->files->get('Filedata');
+        $data = file_get_contents($file->getPathname());
         $success = DataObject\ClassDefinition\Service::importObjectBrickFromJson($objectBrick, $data);
 
         $response = $this->adminJson([
@@ -1102,10 +1122,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $this->checkPermission('objectbricks');
 
-        $objectBrick = DataObject\Objectbrick\Definition::getByKey($request->get('id'));
+        $objectBrick = DataObject\Objectbrick\Definition::getByKey($request->query->get('id'));
 
         if (!$objectBrick instanceof DataObject\Objectbrick\Definition) {
-            $errorMessage = ': Object-Brick with id [ ' . $request->get('id') . ' not found. ]';
+            $errorMessage = ': Object-Brick with id [ ' . $request->query->get('id') . ' not found. ]';
             Logger::error($errorMessage);
 
             throw $this->createNotFoundException($errorMessage);
@@ -1124,7 +1144,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $this->checkPermission('objectbricks');
 
-        $fc = DataObject\Objectbrick\Definition::getByKey($request->get('id'));
+        $fc = DataObject\Objectbrick\Definition::getByKey($request->request->get('id'));
         $fc->delete();
 
         return $this->adminJson(['success' => true]);
@@ -1136,7 +1156,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $list = new DataObject\Objectbrick\Definition\Listing();
         $list = $list->load();
 
-        $forObjectEditor = $request->get('forObjectEditor');
+        $forObjectEditor = $request->query->get('forObjectEditor');
 
         $context = [];
         $layoutDefinitions = [];
@@ -1145,11 +1165,13 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $fieldname = null;
         $className = null;
 
-        $object = DataObject\Concrete::getById((int) $request->get('object_id'));
+        $object = $request->query->has('object_id')
+            ? DataObject\Concrete::getById((int) $request->query->get('object_id'))
+            : null;
 
         if ($request->query->has('class_id') && $request->query->has('field_name')) {
-            $classId = $request->get('class_id');
-            $fieldname = $request->get('field_name');
+            $classId = $request->query->get('class_id');
+            $fieldname = $request->query->get('field_name');
             $classDefinition = DataObject\ClassDefinition::getById($classId);
             $className = $classDefinition->getName();
         }
@@ -1193,7 +1215,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                     ];
                 }
                 if ($forObjectEditor) {
-                    $layoutId = $request->get('layoutId');
+                    $layoutId = $request->query->get('layoutId');
                     $itemLayoutDefinitions = null;
                     if ($layoutId) {
                         $layout = DataObject\ClassDefinition\CustomLayout::getById($layoutId.'.brick.'.$item->getKey());
@@ -1223,7 +1245,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 if ($forObjectEditor) {
                     $layout = $item->getLayoutDefinitions();
 
-                    $currentLayoutId = $request->get('layoutId');
+                    $currentLayoutId = $request->query->get('layoutId');
 
                     $user = $this->getAdminUser();
                     if ($currentLayoutId == -1 && $user->isAdmin()) {
@@ -1256,10 +1278,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
         $event = new GenericEvent($this, [
             'list' => $definitions,
-            'objectId' => $request->get('object_id'),
+            'objectId' => $request->query->get('object_id'),
             'forObjectEditor' => $forObjectEditor,
             'layoutDefinitions' => $layoutDefinitions,
-            'fieldName' => $request->get('field_name'),
+            'fieldName' => $request->query->get('field_name'),
             'object' => $object,
         ]);
         $eventDispatcher->dispatch($event, AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA);
@@ -1281,8 +1303,8 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
         if ($request->query->has('class_id') && $request->query->has('field_name')) {
             $filteredList = [];
-            $classId = $request->get('class_id');
-            $fieldname = $request->get('field_name');
+            $classId = $request->query->get('class_id');
+            $fieldname = $request->query->get('field_name');
             $classDefinition = DataObject\ClassDefinition::getById($classId);
             $className = $classDefinition->getName();
 
@@ -1300,7 +1322,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
                 $layout = $type->getLayoutDefinitions();
 
-                $currentLayoutId = $request->get('layoutId');
+                $currentLayoutId = $request->query->get('layoutId');
 
                 $user = $this->getAdminUser();
                 if ($currentLayoutId == -1 && $user->isAdmin()) {
@@ -1311,10 +1333,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 $context = [
                     'containerType' => 'objectbrick',
                     'containerKey' => $type->getKey(),
-                    'outerFieldname' => $request->get('field_name'),
+                    'outerFieldname' => $request->query->get('field_name'),
                 ];
 
-                $object = DataObject\Concrete::getById((int) $request->get('object_id'));
+                $object = DataObject\Concrete::getById((int) $request->query->get('object_id'));
 
                 DataObject\Service::enrichLayoutDefinition($layout, $object, $context);
                 $type->setLayoutDefinitions($layout);
@@ -1325,7 +1347,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
         $event = new GenericEvent($this, [
             'list' => $list,
-            'objectId' => $request->get('object_id'),
+            'objectId' => $request->query->get('object_id'),
         ]);
         $eventDispatcher->dispatch($event, AdminEvents::CLASS_OBJECTBRICK_LIST_PRE_SEND_DATA);
         $list = $event->getArgument('list');
@@ -1649,7 +1671,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/get-fieldcollection-usages', name: 'getfieldcollectionusages', methods: ['GET'])]
     public function getFieldcollectionUsagesAction(Request $request): Response
     {
-        $key = $request->get('key');
+        $key = $request->query->get('key');
         $result = [];
 
         $classes = new DataObject\ClassDefinition\Listing();
@@ -1675,7 +1697,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/get-bricks-usages', name: 'getbrickusages', methods: ['GET'])]
     public function getBrickUsagesAction(Request $request): Response
     {
-        $classId = $request->get('classId');
+        $classId = $request->query->get('classId');
         $myclass = DataObject\ClassDefinition::getById($classId);
 
         $result = [];
@@ -1701,7 +1723,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     public function getSelectOptionsUsagesAction(Request $request): Response
     {
         $usages = [];
-        $id = $request->get(DataObject\SelectOptions\Config::PROPERTY_ID);
+        $id = $request->query->get(DataObject\SelectOptions\Config::PROPERTY_ID);
         $selectOptionsConfiguration = $this->getSelectOptionsConfig($id);
         foreach ($selectOptionsConfiguration->getFieldsUsedIn() as $className => $fieldNames) {
             foreach ($fieldNames as $fieldName) {
@@ -1826,10 +1848,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($result);
     }
 
-    #[Route('/suggest-custom-layout-identifier', name: 'suggestcustomlayoutidentifier')]
+    #[Route('/suggest-custom-layout-identifier', name: 'suggestcustomlayoutidentifier', methods: ['GET'])]
     public function suggestCustomLayoutIdentifierAction(Request $request): Response
     {
-        $classId = $request->get('classId');
+        $classId = $request->query->get('classId');
 
         $identifier = DataObject\ClassDefinition\CustomLayout::getIdentifier($classId);
 
@@ -1855,26 +1877,26 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($result);
     }
 
-    #[Route('/text-layout-preview', name: 'textlayoutpreview')]
+    #[Route('/text-layout-preview', name: 'textlayoutpreview', methods: ['GET'])]
     public function textLayoutPreviewAction(Request $request): Response
     {
-        $objPath = $request->get('previewObject', '');
-        $className = '\\OpenDxp\\Model\\DataObject\\' . $request->get('className');
+        $objPath = $request->query->get('previewObject', '');
+        $className = '\\OpenDxp\\Model\\DataObject\\' . $request->query->get('className');
         $obj = DataObject::getByPath($objPath) ?? new $className();
 
         $textLayout = new DataObject\ClassDefinition\Layout\Text();
         $textLayout->setName('textLayoutPreview' . $className);
 
         $context = [
-          'data' => $request->get('renderingData'),
+          'data' => $request->query->get('renderingData'),
         ];
 
-        if ($renderingClass = $request->get('renderingClass')) {
+        if ($renderingClass = $request->query->get('renderingClass')) {
             $textLayout->setRenderingClass($renderingClass);
-            $textLayout->setRenderingData($request->get('renderingData', ''));
+            $textLayout->setRenderingData($request->query->get('renderingData', ''));
         }
 
-        if ($staticHtml = $request->get('html')) {
+        if ($staticHtml = $request->query->get('html')) {
             $textLayout->setHtml($staticHtml);
         }
 
@@ -1898,7 +1920,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    #[Route('/video-supported-types', name: 'videosupportedTypestypes')]
+    #[Route('/video-supported-types', name: 'videosupportedTypestypes', methods: ['GET'])]
     public function videoAllowedTypesAction(Request $request, TranslatorInterface $translator): Response
     {
         $videoDef = new DataObject\ClassDefinition\Data\Video();
@@ -1914,14 +1936,11 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($res);
     }
 
-    /**
-     * SELECT OPTIONS
-     */
     #[Route('/select-options-get', name: 'selectoptionsget', methods: [Request::METHOD_GET])]
     public function selectOptionsGetAction(Request $request): JsonResponse
     {
         $this->checkPermission('selectoptions');
-        $id = $request->get(DataObject\SelectOptions\Config::PROPERTY_ID);
+        $id = $request->query->get(DataObject\SelectOptions\Config::PROPERTY_ID);
         $selectOptionsConfiguration = $this->getSelectOptionsConfig($id);
 
         $data = $selectOptionsConfiguration->getObjectVars();
@@ -1937,16 +1956,16 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $this->checkPermission('selectoptions');
 
         try {
-            $id = $request->get(DataObject\SelectOptions\Config::PROPERTY_ID);
+            $id = $request->request->get(DataObject\SelectOptions\Config::PROPERTY_ID);
 
-            if ($request->get('task') === 'add' && (new DataObject\SelectOptions\Config\Listing())->hasConfig($id)) {
+            if ($request->request->get('task') === 'add' && (new DataObject\SelectOptions\Config\Listing())->hasConfig($id)) {
                 throw new Exception('Select options with the same ID already exists (lower/upper cases may be different)');
             }
 
-            $group = $request->get(DataObject\SelectOptions\Config::PROPERTY_GROUP);
-            $useTraits = $request->get(DataObject\SelectOptions\Config::PROPERTY_USE_TRAITS, '');
-            $implementsInterfaces = $request->get(DataObject\SelectOptions\Config::PROPERTY_IMPLEMENTS_INTERFACES, '');
-            $selectOptionsData = $request->get(DataObject\SelectOptions\Config::PROPERTY_SELECT_OPTIONS, 'null');
+            $group = $request->request->get(DataObject\SelectOptions\Config::PROPERTY_GROUP);
+            $useTraits = $request->request->get(DataObject\SelectOptions\Config::PROPERTY_USE_TRAITS, '');
+            $implementsInterfaces = $request->request->get(DataObject\SelectOptions\Config::PROPERTY_IMPLEMENTS_INTERFACES, '');
+            $selectOptionsData = $request->request->get(DataObject\SelectOptions\Config::PROPERTY_SELECT_OPTIONS, 'null');
             $selectOptionsConfiguration = DataObject\SelectOptions\Config::createFromData(
                 [
                     DataObject\SelectOptions\Config::PROPERTY_ID => $id,
@@ -1990,7 +2009,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 'iconCls' => 'opendxp_icon_select',
             ];
 
-            if ((int)$request->get('grouped', 0) === 0 || !$selectOptionConfig->hasGroup()) {
+            if ((int)$request->query->get('grouped', 0) === 0 || !$selectOptionConfig->hasGroup()) {
                 $configurations[] = $configurationData;
 
                 continue;
@@ -2030,7 +2049,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $this->checkPermission('selectoptions');
 
         try {
-            $id = $request->get(DataObject\SelectOptions\Config::PROPERTY_ID);
+            $id = $request->request->get(DataObject\SelectOptions\Config::PROPERTY_ID);
             $this->getSelectOptionsConfig($id)->delete();
 
             return $this->adminJson(['success' => true]);

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1398,7 +1398,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/bulk-commit', name: 'bulkcommit', methods: ['POST'])]
     public function bulkCommitAction(Request $request): JsonResponse
     {
-        $data = json_decode($request->get('data'), true);
+        $data = json_decode($request->request->get('data'), true);
 
         $session = Session::getSessionBag($request->getSession(), 'opendxp_objects');
         $filename = $session->get('class_bulk_import_file');
@@ -1501,9 +1501,9 @@ class ClassController extends AdminAbstractController implements KernelControlle
     #[Route('/bulk-export-prepare', name: 'bulkexportprepare', methods: ['POST'])]
     public function bulkExportPrepareAction(Request $request): Response
     {
-        $data = $request->get('data');
+        $data = $request->request->get('data');
 
-        Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($data): void {
+        Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($data): void {
             $session->set('class_bulk_export_settings', $data);
         }, 'opendxp_objects');
 

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1363,7 +1363,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $result = [];
 
-        /** @var UploadedFile $tmpName */
+        /** @var UploadedFile $uploadFile */
         $uploadFile = $request->files->get('Filedata');
 
         $json = file_get_contents($uploadFile->getPathname());

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1363,10 +1363,12 @@ class ClassController extends AdminAbstractController implements KernelControlle
     {
         $result = [];
 
-        $tmpName = $_FILES['Filedata']['tmp_name'];
-        $json = file_get_contents($tmpName);
+        /** @var UploadedFile $tmpName */
+        $uploadFile = $request->files->get('Filedata');
 
-        $tmpName = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/bulk-import-' . uniqid() . '.tmp';
+        $json = file_get_contents($uploadFile->getPathname());
+
+        $tmpName = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/bulk-import-' . uniqid('', false) . '.tmp';
         file_put_contents($tmpName, $json);
 
         Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($tmpName): void {

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -2009,7 +2009,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 'iconCls' => 'opendxp_icon_select',
             ];
 
-            if ((int)$request->query->get('grouped', 0) === 0 || !$selectOptionConfig->hasGroup()) {
+            if ((int)$request->query->get('grouped', '0') === 0 || !$selectOptionConfig->hasGroup()) {
                 $configurations[] = $configurationData;
 
                 continue;

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -196,8 +196,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $start = (int) $request->get('start');
         }
 
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
         if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
             $orderKey = $sortingSettings['orderKey'];
             $order = $sortingSettings['order'];
@@ -315,15 +314,15 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/collections', name: 'collections', methods: ['POST', 'PUT'])]
     public function collectionsAction(Request $request): JsonResponse
     {
-        if ($request->get('data')) {
-            $dataParam = $request->get('data');
+        if ($request->request->has('data')) {
+            $dataParam = $request->request->get('data');
             $data = $this->decodeJson($dataParam);
 
             $id = $data['id'];
             $config = Classificationstore\CollectionConfig::getById($id);
 
             foreach ($data as $key => $value) {
-                if ($key != 'id') {
+                if ($key !== 'id') {
                     $setter = 'set' . $key;
                     $config->$setter($value);
                 }
@@ -347,23 +346,22 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $orderKey = 'name';
         $order = 'ASC';
 
-        if ($request->get('dir')) {
-            $order = $request->get('dir');
+        if ($request->query->has('dir')) {
+            $order = $request->query->get('dir');
         }
 
-        if ($request->get('sort')) {
-            $orderKey = $request->get('sort');
+        if ($request->query->has('sort')) {
+            $orderKey = $request->query->get('sort');
         }
 
-        if ($request->get('limit')) {
-            $limit = (int) $request->get('limit');
+        if ($request->query->has('limit')) {
+            $limit = (int) $request->query->get('limit');
         }
-        if ($request->get('start')) {
-            $start = (int) $request->get('start');
+        if ($request->query->has('start')) {
+            $start = (int) $request->query->get('start');
         }
 
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
         if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
             $orderKey = $sortingSettings['orderKey'];
             $order = $sortingSettings['order'];
@@ -384,8 +382,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $conditionParts = [];
         $db = Db::get();
 
-        $searchfilter = $request->get('searchfilter');
-        if ($searchfilter) {
+
+        if ($request->query->has('searchfilter')) {
+            $searchfilter = $request->query->get('searchfilter');
             $searchFilterConditions = [];
 
             $searchTerms = [$searchfilter, ...$this->getTranslatedSearchFilterTerms($searchfilter)];
@@ -400,8 +399,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $conditionParts[] = '(storeId = ' . $db->quote($storeId) . ')';
         }
 
-        if ($request->get('filter')) {
-            $filterString = $request->get('filter');
+        if ($request->query->has('filter')) {
+            $filterString = $request->query->get('filter');
             $filters = json_decode($filterString);
             /** @var stdClass $f */
             foreach ($filters as $f) {
@@ -413,7 +412,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
             }
         }
 
-        if ($oid = $request->get('oid')) {
+        if ($request->query->has('oid')) {
+            $oid = $request->query->get('oid');
             $object = DataObject\Concrete::getById((int) $oid);
             $class = $object->getClass();
             /** @var DataObject\ClassDefinition\Data\Classificationstore $fd */
@@ -465,15 +465,15 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/groups', name: 'groupsaction', methods: ['POST', 'PUT'])]
     public function groupsAction(Request $request): JsonResponse
     {
-        if ($request->get('data')) {
-            $dataParam = $request->get('data');
+        if ($request->request->has('data')) {
+            $dataParam = $request->request->get('data');
             $data = $this->decodeJson($dataParam);
 
             $id = $data['id'];
             $config = Classificationstore\GroupConfig::getById($id);
 
             foreach ($data as $key => $value) {
-                if ($key != 'id') {
+                if ($key !== 'id') {
                     $setter = 'set' . $key;
                     $config->$setter($value);
                 }
@@ -497,12 +497,11 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $orderKey = 'sorter';
         $order = 'ASC';
 
-        if ($request->get('dir')) {
-            $order = $request->get('dir');
+        if ($request->query->has('dir')) {
+            $order = $request->query->get('dir');
         }
 
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
         if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
             $orderKey = $sortingSettings['orderKey'];
             $order = $sortingSettings['order'];
@@ -513,11 +512,11 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $order = 'DESC';
         }
 
-        if ($request->get('limit')) {
-            $limit = (int) $request->get('limit');
+        if ($request->query->has('limit')) {
+            $limit = (int) $request->query->get('limit');
         }
-        if ($request->get('start')) {
-            $start = (int) $request->get('start');
+        if ($request->query->has('start')) {
+            $start = (int) $request->query->get('start');
         }
 
         $list = new Classificationstore\CollectionGroupRelation\Listing();
@@ -530,9 +529,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $list->setOrderKey($mapping[$orderKey] ?? $orderKey);
         $condition = '';
 
-        if ($request->get('filter')) {
+        if ($request->query->has('filter')) {
             $db = Db::get();
-            $filterString = $request->get('filter');
+            $filterString = $request->query->get('filter');
             $filters = json_decode($filterString);
 
             $count = 0;
@@ -585,8 +584,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/collection-relations', name: 'collectionrelations', methods: ['POST', 'PUT'])]
     public function collectionRelationsAction(Request $request): JsonResponse
     {
-        if ($request->get('data')) {
-            $dataParam = $request->get('data');
+        if ($request->request->has('data')) {
+            $dataParam = $request->request->get('data');
             $data = $this->decodeJson($dataParam);
 
             if (count($data) === count($data, 1)) {
@@ -633,7 +632,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
     {
         $db = Db::get();
 
-        $storeId = $request->get('storeId');
+        $storeId = $request->query->get('storeId');
 
         $mapping = [
             'groupName' => DataObject\Classificationstore\GroupConfig\Dao::TABLE_NAME_GROUPS .'.name',
@@ -646,15 +645,14 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $orderKey = 'name';
         $order = 'ASC';
 
-        if ($request->get('dir')) {
-            $order = $request->get('dir');
+        if ($request->query->get('dir')) {
+            $order = $request->query->get('dir');
         }
 
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
         if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
             $orderKey = $sortingSettings['orderKey'];
-            if ($orderKey == 'keyName') {
+            if ($orderKey === 'keyName') {
                 $orderKey = 'name';
             }
             $order = $sortingSettings['order'];
@@ -665,11 +663,11 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $order = 'DESC';
         }
 
-        if ($request->get('limit')) {
-            $limit = (int) $request->get('limit');
+        if ($request->query->has('limit')) {
+            $limit = (int) $request->query->get('limit');
         }
-        if ($request->get('start')) {
-            $start = (int) $request->get('start');
+        if ($request->query->has('start')) {
+            $start = (int) $request->query->get('start');
         }
 
         $list = new Classificationstore\KeyGroupRelation\Listing();
@@ -683,9 +681,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
 
         $conditionParts = [];
 
-        if ($request->get('filter')) {
+        if ($request->query->has('filter')) {
             $db = Db::get();
-            $filterString = $request->get('filter');
+            $filterString = $request->query->get('filter');
             $filters = json_decode($filterString);
             /** @var stdClass $f */
             foreach ($filters as $f) {
@@ -700,7 +698,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
 
         $conditionParts[] = '  groupId IN (select id from classificationstore_groups where storeId = ' . $db->quote($storeId) . ')';
 
-        $searchfilter = $request->get('searchfilter');
+        $searchfilter = $request->query->get('searchfilter');
         if ($searchfilter) {
             $searchFilterConditions = [];
 
@@ -760,8 +758,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $relationIds = json_decode($relationIds, true);
         }
 
-        if ($request->get('dir')) {
-            $order = $request->get('dir');
+        if ($request->query->has('dir')) {
+            $order = $request->query->get('dir');
         }
 
         $allParams = [...$request->request->all(), ...$request->query->all()];
@@ -777,14 +775,14 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $order = 'DESC';
         }
 
-        if ($request->get('limit')) {
-            $limit = (int) $request->get('limit');
+        if ($request->query->has('limit')) {
+            $limit = (int) $request->query->get('limit');
         } elseif (is_array($relationIds)) {
             $limit = count($relationIds);
         }
 
-        if ($request->get('start')) {
-            $start = (int) $request->get('start');
+        if ($request->query->has('start')) {
+            $start = (int) $request->query->get('start');
         }
 
         $list = new Classificationstore\KeyGroupRelation\Listing();
@@ -798,9 +796,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $list->setOrderKey($orderKey);
         $conditionParts = [];
 
-        if ($request->get('filter')) {
+        if ($request->query->has('filter')) {
             $db = Db::get();
-            $filterString = $request->get('filter');
+            $filterString = $request->query->get('filter');
             $filters = json_decode($filterString);
             /** @var stdClass $f */
             foreach ($filters as $f) {
@@ -813,8 +811,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
             }
         }
 
-        if (!$request->get('relationIds')) {
-            $groupId = $request->get('groupId');
+        if (!$request->query->has('relationIds')) {
+            $groupId = $request->query->get('groupId');
             $conditionParts[] = ' groupId = ' . $list->quote($groupId);
         }
 
@@ -868,8 +866,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/relations', name: 'relations', methods: ['POST', 'PUT'])]
     public function relationsAction(Request $request): JsonResponse
     {
-        if ($request->get('data')) {
-            $dataParam = $request->get('data');
+        if ($request->request->has('data')) {
+            $dataParam = $request->request->get('data');
             $data = $this->decodeJson($dataParam);
 
             $keyId = $data['keyId'];
@@ -1008,10 +1006,10 @@ class ClassificationstoreController extends AdminAbstractController implements K
     {
         $this->checkPermission('objects');
 
-        $ids = $this->decodeJson($request->get('groupIds'));
+        $ids = $this->decodeJson($request->request->get('groupIds'));
         $oid = $request->request->getInt('oid');
-        $object = DataObject\Concrete::getById($oid);
-        $fieldname = $request->get('fieldname');
+        $object = $oid === 0 ? null : DataObject\Concrete::getById($oid);
+        $fieldname = $request->request->get('fieldname');
 
         $keyCondition = 'groupId in (' . implode(',', array_fill(0, count($ids), '?')) . ')';
 
@@ -1082,8 +1080,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/properties', name: 'propertiesget', methods: ['GET'])]
     public function propertiesGetAction(Request $request): JsonResponse
     {
-        $storeId = (int) $request->get('storeId');
-        $frameName = $request->get('frameName');
+        $storeId = (int) $request->query->get('storeId');
+        $frameName = $request->query->get('frameName');
         $db = \OpenDxp\Db::get();
 
         $conditionParts = [];
@@ -1129,8 +1127,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $order = $request->get('dir');
         }
 
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
         if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
             $orderKey = $sortingSettings['orderKey'];
             $order = $sortingSettings['order'];
@@ -1141,16 +1138,16 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $order = 'DESC';
         }
 
-        if ($request->get('limit')) {
-            $limit = (int) $request->get('limit');
+        if ($request->query->has('limit')) {
+            $limit = (int) $request->query->get('limit');
         }
-        if ($request->get('start')) {
-            $start = (int) $request->get('start');
+        if ($request->query->has('start')) {
+            $start = (int) $request->query->get('start');
         }
 
         $list = new Classificationstore\KeyConfig\Listing();
 
-        if ($limit > 0 && !$request->get('groupIds') && !$request->get('keyIds')) {
+        if ($limit > 0 && !$request->query->get('groupIds') && !$request->query->get('keyIds')) {
             $list->setLimit($limit);
         }
         $list->setOffset($start);
@@ -1226,8 +1223,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/properties', name: 'properties', methods: ['POST', 'PUT'])]
     public function propertiesAction(Request $request): JsonResponse
     {
-        if ($request->get('data')) {
-            $dataParam = $request->get('data');
+        if ($request->request->has('data')) {
+            $dataParam = $request->request->get('data');
             $data = $this->decodeJson($dataParam);
 
             $id = $data['id'];

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -83,8 +83,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     {
         $this->checkPermission('classificationstore');
 
-        $keyId = (int) $request->get('keyId');
-        $groupId = (int) $request->get('groupId');
+        $keyId = $request->request->getInt('keyId');
+        $groupId = $request->request->getInt('groupId');
 
         $config = new Classificationstore\KeyGroupRelation();
         $config->setKeyId($keyId);
@@ -116,8 +116,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     {
         $this->checkPermission('classificationstore');
 
-        $name = SecurityHelper::convertHtmlSpecialChars($request->get('name'));
-        $storeId = (int) $request->get('storeId');
+        $name = SecurityHelper::convertHtmlSpecialChars($request->request->get('name'));
+        $storeId = $request->request->getInt('storeId');
         $config = Classificationstore\GroupConfig::getByName($name, $storeId);
 
         if (!$config) {
@@ -140,7 +140,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
     {
         $this->checkPermission('classificationstore');
 
-        $name = SecurityHelper::convertHtmlSpecialChars($request->get('name'));
+        $name = SecurityHelper::convertHtmlSpecialChars($request->request->get('name'));
 
         $config = Classificationstore\StoreConfig::getByName($name);
 
@@ -163,8 +163,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     {
         $this->checkPermission('classificationstore');
 
-        $name = SecurityHelper::convertHtmlSpecialChars($request->get('name'));
-        $storeId = (int) $request->get('storeId');
+        $name = SecurityHelper::convertHtmlSpecialChars($request->request->get('name'));
+        $storeId = $request->request->getInt('storeId');
         $config = Classificationstore\CollectionConfig::getByName($name, $storeId);
 
         if (!$config) {
@@ -183,17 +183,17 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $this->checkPermission('objects');
 
         $start = 0;
-        $limit = $request->get('limit') ? (int) $request->get('limit') : 15;
+        $limit = $request->query->get('limit') ? (int) $request->query->get('limit') : 15;
 
         $orderKey = 'name';
         $order = 'ASC';
 
-        if ($request->get('dir')) {
-            $order = $request->get('dir');
+        if ($request->query->has('dir')) {
+            $order = $request->query->get('dir');
         }
 
-        if ($request->get('start')) {
-            $start = (int) $request->get('start');
+        if ($request->query->has('start')) {
+            $start = (int) $request->query->get('start');
         }
 
         $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
@@ -209,11 +209,11 @@ class ClassificationstoreController extends AdminAbstractController implements K
 
         $storeIdFromDefinition = 0;
         $allowedCollectionIds = [];
-        if ($oid = $request->get('oid')) {
+        if ($oid = $request->query->get('oid')) {
             $object = DataObject\Concrete::getById((int) $oid);
             $class = $object->getClass();
             /** @var DataObject\ClassDefinition\Data\Classificationstore $fd */
-            $fd = $class->getFieldDefinition($request->get('fieldname'));
+            $fd = $class->getFieldDefinition($request->query->get('fieldname'));
             $allowedGroupIds = $fd->getAllowedGroupIds();
 
             if ($allowedGroupIds) {
@@ -239,7 +239,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $conditionParts = [];
         $db = Db::get();
 
-        $searchfilter = $request->get('searchfilter');
+        $searchfilter = $request->query->get('searchfilter');
         if ($searchfilter) {
             $searchFilterConditions = [];
 
@@ -251,13 +251,13 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $conditionParts[] = '('.implode(' OR ', $searchFilterConditions).')';
         }
 
-        $storeId = $request->get('storeId');
+        $storeId = $request->query->get('storeId');
         $storeId = $storeId ? (int) $storeId : $storeIdFromDefinition;
 
         $conditionParts[] = ' (storeId = ' . $db->quote($storeId) . ')';
 
-        if ($request->get('filter')) {
-            $filterString = $request->get('filter');
+        if ($request->query->has('filter')) {
+            $filterString = $request->query->get('filter');
             $filters = json_decode($filterString);
             /** @var stdClass $f */
             foreach ($filters as $f) {
@@ -417,7 +417,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $object = DataObject\Concrete::getById((int) $oid);
             $class = $object->getClass();
             /** @var DataObject\ClassDefinition\Data\Classificationstore $fd */
-            $fd = $class->getFieldDefinition($request->get('fieldname'));
+            $fd = $class->getFieldDefinition($request->query->get('fieldname'));
             $allowedGroupIds = $fd->getAllowedGroupIds();
 
             if ($allowedGroupIds) {
@@ -752,7 +752,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $limit = 15;
         $orderKey = 'name';
         $order = 'ASC';
-        $relationIds = $request->get('relationIds');
+        $relationIds = $request->query->get('relationIds');
 
         if ($relationIds) {
             $relationIds = json_decode($relationIds, true);
@@ -762,8 +762,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $order = $request->query->get('dir');
         }
 
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
 
         if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
             $orderKey = $mapping[$sortingSettings['orderKey']] ?? $sortingSettings['orderKey'];
@@ -898,7 +897,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
     {
         $this->checkPermission('objects');
 
-        $ids = $this->decodeJson($request->get('collectionIds'));
+        $ids = $this->decodeJson($request->request->get('collectionIds'));
         $data = [];
 
         if ($ids) {
@@ -922,7 +921,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             if ($object) {
                 $class = $object->getClass();
                 /** @var DataObject\ClassDefinition\Data\Classificationstore $fd */
-                $fd = $class->getFieldDefinition($request->get('fieldname'));
+                $fd = $class->getFieldDefinition($request->request->get('fieldname'));
                 $allowedGroupIds = $fd->getAllowedGroupIds();
             }
 
@@ -934,7 +933,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             }
 
             if ($groupIdList) {
-                $fieldname = $request->get('fieldname');
+                $fieldname = $request->request->get('fieldname');
                 $groupList = new Classificationstore\GroupConfig\Listing();
                 $groupCondition = 'id in (' . implode(',', $groupIdList) . ')';
                 $groupList->setCondition($groupCondition);
@@ -955,7 +954,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
                         'id' => $groupData->getId(),
                         'description' => $groupData->getDescription(),
                         'keys' => [],
-                        'sorter' => intval($mappedData[$groupData->getId()]['sorter']),
+                        'sorter' => (int) $mappedData[$groupData->getId()]['sorter'],
                         'collectionId' => $mappedData[$groupId]['colId'],
                     ];
                 }
@@ -1123,8 +1122,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $orderKey = 'name';
         $order = 'ASC';
 
-        if ($request->get('dir')) {
-            $order = $request->get('dir');
+        if ($request->query->has('dir')) {
+            $order = $request->query->get('dir');
         }
 
         $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
@@ -1154,7 +1153,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $list->setOrder($order);
         $list->setOrderKey($orderKey);
 
-        $searchfilter = $request->get('searchfilter');
+        $searchfilter = $request->query->get('searchfilter');
         if ($searchfilter) {
             $conditionParts[] = '(name LIKE ' . $db->quote('%' . $searchfilter . '%') . ' OR description LIKE ' . $db->quote('%'. $searchfilter . '%') . ')';
         }
@@ -1163,8 +1162,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $conditionParts[] = '(storeId = '. $db->quote($storeId) . ')';
         }
 
-        if ($request->get('filter')) {
-            $filterString = $request->get('filter');
+        if ($request->query->has('filter')) {
+            $filterString = $request->query->get('filter');
             $filters = json_decode($filterString);
             /** @var stdClass $f */
             foreach ($filters as $f) {
@@ -1178,14 +1177,14 @@ class ClassificationstoreController extends AdminAbstractController implements K
         $condition = implode(' AND ', $conditionParts);
         $list->setCondition($condition);
 
-        if ($request->get('groupIds') || $request->get('keyIds')) {
+        if ($request->query->get('groupIds') || $request->query->get('keyIds')) {
             $db = Db::get();
 
-            if ($request->get('groupIds')) {
-                $ids = $this->decodeJson($request->get('groupIds'));
+            if ($request->query->get('groupIds')) {
+                $ids = $this->decodeJson($request->query->get('groupIds'));
                 $col = 'group';
             } else {
-                $ids = $this->decodeJson($request->get('keyIds'));
+                $ids = $this->decodeJson($request->query->get('keyIds'));
                 $col = 'id';
             }
 
@@ -1290,8 +1289,8 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/add-property', name: 'addproperty', methods: ['POST'])]
     public function addPropertyAction(Request $request): JsonResponse
     {
-        $name = $request->get('name');
-        $storeId = (int) $request->get('storeId');
+        $name = $request->request->get('name');
+        $storeId = $request->request->getInt('storeId');
 
         $definition = [
             'fieldtype' => 'input',
@@ -1299,6 +1298,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             'title' => $name,
             'datatype' => 'data',
         ];
+
         $config = new Classificationstore\KeyConfig();
         $config->setName($name);
         $config->setTitle($name);
@@ -1388,20 +1388,20 @@ class ClassificationstoreController extends AdminAbstractController implements K
     #[Route('/get-page', name: 'getpage', methods: ['GET'])]
     public function getPageAction(Request $request): JsonResponse
     {
-        $tableSuffix = $request->get('table');
+        $tableSuffix = $request->query->get('table');
         if (!ArrayHelper::inArrayCaseInsensitive($tableSuffix, ['keys', 'groups'])) {
             $tableSuffix = 'keys';
         }
 
         $table = 'classificationstore_' . $tableSuffix;
         $db = \OpenDxp\Db::get();
-        $id = (int) $request->get('id');
-        $storeId = (int) $request->get('storeId');
-        $pageSize = (int) $request->get('pageSize');
+        $id = (int) $request->query->get('id');
+        $storeId = (int) $request->query->get('storeId');
+        $pageSize = (int) $request->query->get('pageSize');
 
-        if ($request->get('sortKey')) {
-            $sortKey = $request->get('sortKey');
-            $sortDir = $request->get('sortDir');
+        if ($request->query->get('sortKey')) {
+            $sortKey = $request->query->get('sortKey');
+            $sortDir = $request->query->get('sortDir');
         } else {
             $sortKey = 'name';
             $sortDir = 'ASC';

--- a/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
+++ b/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
@@ -64,7 +64,7 @@ trait DataObjectActionsTrait
 
         $requestedLanguage = $allParams['language'] ?? null;
         if ($requestedLanguage) {
-            if ($requestedLanguage != 'default') {
+            if ($requestedLanguage !== 'default') {
                 $request->setLocale($requestedLanguage);
             }
         } else {
@@ -124,7 +124,7 @@ trait DataObjectActionsTrait
             $objects = [];
             foreach ($list->getObjects() as $object) {
                 if ($csvMode) {
-                    $o = DataObject\Service::getCsvDataForObject($object, $requestedLanguage, $request->get('fields'), GridData\DataObject::getHelperDefinitions(), $localeService, 'title', false, $allParams['context']);
+                    $o = DataObject\Service::getCsvDataForObject($object, $requestedLanguage, $allParams['fields'], GridData\DataObject::getHelperDefinitions(), $localeService, 'title', false, $allParams['context']);
                     // Like for treeGetChildrenByIdAction, so we respect isAllowed method which can be extended (object DI) for custom permissions, so relying only users_workspaces_object is insufficient and could lead security breach
                     if ($object->isAllowed('list')) {
                         $objects[] = $o;
@@ -149,6 +149,7 @@ trait DataObjectActionsTrait
                     'list' => $result,
                     'context' => $allParams,
                 ]);
+
                 $eventDispatcher->dispatch($afterListLoadEvent, AdminEvents::OBJECT_LIST_AFTER_LIST_LOAD);
                 $result = $afterListLoadEvent->getArgument('list');
             }

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -88,8 +88,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/tree-get-children-by-id', name: 'treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $filter = $request->get('filter');
+        $filter = $request->query->get('filter');
         $object = DataObject::getById((int) $request->get('node'));
         $objectTypes = [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_FOLDER];
         $objects = [];
@@ -104,9 +103,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
 
         if ($object->hasChildren($objectTypes)) {
-            $offset = (int)$request->get('start');
-            $limit = (int)$request->get('limit', 100000000);
-            if ($view = $request->get('view', '')) {
+            $offset = (int)$request->query->get('start');
+            $limit = (int)$request->query->get('limit', 100000000);
+            if ($view = $request->query->get('view', '')) {
                 $cv = $this->elementService->getCustomViewById($view) ?? [];
             }
 
@@ -140,7 +139,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $beforeListLoadEvent = new GenericEvent($this, [
                 'list' => $childrenList,
-                'context' => $allParams,
+                'context' => $request->query->all(),
             ]);
             $eventDispatcher->dispatch($beforeListLoadEvent, AdminEvents::OBJECT_LIST_BEFORE_LIST_LOAD);
 
@@ -1721,20 +1720,20 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         $transactionId = time();
         $pasteJobs = [];
 
-        Tool\Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($transactionId): void {
+        Tool\Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($transactionId): void {
             $session->set((string) $transactionId, ['idMapping' => []]);
         }, 'opendxp_copy');
 
-        if ($request->get('type') == 'recursive' || $request->get('type') == 'recursive-update-references') {
-            $object = DataObject::getById((int) $request->get('sourceId'));
+        if ($request->query->get('type') === 'recursive' || $request->query->get('type') === 'recursive-update-references') {
+            $object = DataObject::getById((int) $request->query->get('sourceId'));
 
             // first of all the new parent
             $pasteJobs[] = [[
                 'url' => $this->generateUrl('opendxp_admin_dataobject_dataobject_copy'),
                 'method' => 'POST',
                 'params' => [
-                    'sourceId' => $request->get('sourceId'),
-                    'targetId' => $request->get('targetId'),
+                    'sourceId' => $request->query->get('sourceId'),
+                    'targetId' => $request->query->get('targetId'),
                     'type' => 'child',
                     'transactionId' => $transactionId,
                     'saveParentId' => true,
@@ -1757,8 +1756,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                             'method' => 'POST',
                             'params' => [
                                 'sourceId' => $id,
-                                'targetParentId' => $request->get('targetId'),
-                                'sourceParentId' => $request->get('sourceId'),
+                                'targetParentId' => $request->query->get('targetId'),
+                                'sourceParentId' => $request->query->get('sourceId'),
                                 'type' => 'child',
                                 'transactionId' => $transactionId,
                             ],
@@ -1767,28 +1766,28 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 }
 
                 // add id-rewrite steps
-                if ($request->get('type') == 'recursive-update-references') {
+                if ($request->query->get('type') === 'recursive-update-references') {
                     for ($i = 0; $i < (count($childIds) + 1); $i++) {
                         $pasteJobs[] = [[
                             'url' => $this->generateUrl('opendxp_admin_dataobject_dataobject_copyrewriteids'),
                             'method' => 'PUT',
                             'params' => [
                                 'transactionId' => $transactionId,
-                                '_dc' => uniqid(),
+                                '_dc' => uniqid('', false),
                             ],
                         ]];
                     }
                 }
             }
-        } elseif ($request->get('type') == 'child' || $request->get('type') == 'replace') {
+        } elseif ($request->query->get('type') === 'child' || $request->query->get('type') === 'replace') {
             // the object itself is the last one
             $pasteJobs[] = [[
                 'url' => $this->generateUrl('opendxp_admin_dataobject_dataobject_copy'),
                 'method' => 'POST',
                 'params' => [
-                    'sourceId' => $request->get('sourceId'),
-                    'targetId' => $request->get('targetId'),
-                    'type' => $request->get('type'),
+                    'sourceId' => $request->query->get('sourceId'),
+                    'targetId' => $request->query->get('targetId'),
+                    'type' => $request->query->get('type'),
                     'transactionId' => $transactionId,
                 ],
             ]];
@@ -1825,7 +1824,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         $object->save();
 
         // write the store back to the session
-        Tool\Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($transactionId, $idStore): void {
+        Tool\Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($transactionId, $idStore): void {
             $session->set($transactionId, $idStore);
         }, 'opendxp_copy');
 

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1309,7 +1309,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $objectFromDatabase = DataObject\Concrete::getById((int) $request->get('id'));
+        $objectFromDatabase = DataObject\Concrete::getById((int) $request->request->get('id'));
 
         if (!$objectFromDatabase instanceof DataObject\Concrete) {
             return $this->adminJson(['success' => false, 'message' => 'Could not find object']);
@@ -1344,35 +1344,35 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             }
         }
 
-        if ($request->get('data')) {
+        if ($request->request->has('data')) {
             try {
-                $this->applyChanges($object, $this->decodeJson($request->get('data')));
+                $this->applyChanges($object, $this->decodeJson($request->request->get('data')));
             } catch (Throwable) {
-                $this->applyChanges($objectFromDatabase, $this->decodeJson($request->get('data')));
+                $this->applyChanges($objectFromDatabase, $this->decodeJson($request->request->get('data')));
             }
         }
 
         $this->assignPropertiesFromEditmode($request, $object);
         $this->applySchedulerDataToElement($request, $object, $this->getAdminUser());
 
-        if (($request->get('task') === 'unpublish' && !$object->isAllowed('unpublish')) || ($request->get('task') === 'publish' && !$object->isAllowed('publish'))) {
+        if (($request->query->get('task') === 'unpublish' && !$object->isAllowed('unpublish')) || ($request->query->get('task') === 'publish' && !$object->isAllowed('publish'))) {
             throw $this->createAccessDeniedHttpException();
         }
 
-        if ($request->get('task') === 'unpublish') {
+        if ($request->query->get('task') === 'unpublish') {
             $object->setPublished(false);
         }
 
-        if ($request->get('task') === 'publish') {
+        if ($request->query->get('task') === 'publish') {
             $object->setPublished(true);
         }
 
         // unpublish and save version is possible without checking mandatory fields
-        if (in_array($request->get('task'), ['unpublish', 'version', 'autoSave'])) {
+        if (in_array($request->query->get('task'), ['unpublish', 'version', 'autoSave'])) {
             $object->setOmitMandatoryCheck(true);
         }
 
-        if (($request->get('task') === 'publish') || ($request->get('task') === 'unpublish')) {
+        if (($request->query->get('task') === 'publish') || ($request->query->get('task') === 'unpublish')) {
             // disabled for now: see different approach [Elements] Show users who are working on the same element #9381
             // https://github.com/pimcore/pimcore/issues/9381
             //            if ($data) {
@@ -1386,7 +1386,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $newObject = DataObject::getById($object->getId(), ['force' => true]);
 
-            if ($request->get('task') === 'publish') {
+            if ($request->query->get('task') === 'publish') {
                 $object->deleteAutoSaveVersions($this->getAdminUser()->getId());
             }
 
@@ -1400,7 +1400,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             ]);
         }
 
-        if ($request->get('task') === 'session') {
+        if ($request->query->get('task') === 'session') {
             DataObject\Service::saveElementToSession($object, $request->getSession()->getId(), '');
 
             return $this->adminJson(['success' => true]);
@@ -1480,7 +1480,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/save-folder', name: 'savefolder', methods: ['PUT'])]
     public function saveFolderAction(Request $request): JsonResponse
     {
-        $object = DataObject::getById((int) $request->get('id'));
+        $object = DataObject::getById((int) $request->request->get('id'));
 
         if (!$object) {
             throw $this->createNotFoundException('Object not found');
@@ -1489,7 +1489,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         if ($object->isAllowed('publish')) {
             try {
                 // general settings
-                $general = $this->decodeJson($request->get('general'));
+                $general = $this->decodeJson($request->request->get('general'));
                 $object->setValues($general);
                 $object->setUserModification($this->getAdminUser()->getId());
 

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -104,7 +104,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
         if ($object->hasChildren($objectTypes)) {
             $offset = (int)$request->query->get('start');
-            $limit = (int)$request->query->get('limit', 100000000);
+            $limit = (int)$request->query->get('limit', '100000000');
             if ($view = $request->query->get('view', '')) {
                 $cv = $this->elementService->getCustomViewById($view) ?? [];
             }

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -89,7 +89,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     public function treeGetChildrenByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $filter = $request->query->get('filter');
-        $object = DataObject::getById((int) $request->get('node'));
+        $object = DataObject::getById((int) $request->query->get('node'));
         $objectTypes = [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_FOLDER];
         $objects = [];
         $cv = [];
@@ -179,9 +179,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 'total' => $total,
                 'overflow' => !is_null($filter) && ($filteredTotalCount > $limit),
                 'nodes' => $objects,
-                'fromPaging' => (int)$request->get('fromPaging'),
-                'filter' => $request->get('filter') ?: '',
-                'inSearch' => (int)$request->get('inSearch'),
+                'fromPaging' => (int)$request->query->get('fromPaging'),
+                'filter' => $request->query->get('filter') ?: '',
+                'inSearch' => (int)$request->query->get('inSearch'),
             ]);
         }
 
@@ -243,11 +243,11 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/get-id-path-paging-info', name: 'getidpathpaginginfo', methods: ['GET'])]
     public function getIdPathPagingInfoAction(Request $request): JsonResponse
     {
-        $path = $request->get('path');
+        $path = $request->query->get('path');
         $pathParts = explode('/', $path);
         $id = (int) array_pop($pathParts);
 
-        $limit = $request->get('limit');
+        $limit = $request->query->get('limit');
 
         if (empty($limit)) {
             $limit = 30;
@@ -432,7 +432,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $this->addAdminStyle($object, ElementAdminStyleEvent::CONTEXT_EDITOR, $objectData['general']);
 
-            $currentLayoutId = $request->get('layoutId');
+            $currentLayoutId = $request->query->get('layoutId');
 
             $validLayouts = DataObject\Service::getValidLayouts($object);
 
@@ -562,11 +562,11 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             return new JsonResponse(['success'=> false, 'message' => 'Object not found.']);
         }
 
-        if ($request->get('changedData')) {
-            $this->applyChanges($object, $this->decodeJson($request->get('changedData')));
+        if ($request->request->get('changedData')) {
+            $this->applyChanges($object, $this->decodeJson($request->request->get('changedData')));
         }
 
-        $fieldDefinitionConfig = json_decode($request->get('fieldDefinition'), true);
+        $fieldDefinitionConfig = json_decode($request->request->get('fieldDefinition'), true);
         /**
          * @var DataObject\ClassDefinition\Data\Select|DataObject\ClassDefinition\Data\Multiselect $fieldDefinition
          */
@@ -582,7 +582,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 : OptionsProviderResolver::MODE_SELECT
         );
 
-        $context = json_decode($request->get('context'), true) ?? [];
+        $context = json_decode($request->request->get('context'), true) ?? [];
         $options = $optionsProvider->getOptions(
             [
                 'object' => $object,
@@ -756,7 +756,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/get-folder', name: 'getfolder', methods: ['GET'])]
     public function getFolderAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
-        $objectId = (int)$request->get('id');
+        $objectId = (int)$request->query->get('id');
         $object = DataObject::getById($objectId);
 
         if (!$object) {
@@ -843,14 +843,14 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     public function addAction(Request $request, Model\FactoryInterface $modelFactory): JsonResponse
     {
         $message = '';
-        $parent = DataObject::getById((int) $request->get('parentId'));
+        $parent = DataObject::getById((int) $request->request->get('parentId'));
 
         if (!$parent->isAllowed('create')) {
             $message = 'prevented adding object because of missing permissions';
             Logger::debug($message);
         }
 
-        $intendedPath = $parent->getRealFullPath() . '/' . $request->get('key');
+        $intendedPath = $parent->getRealFullPath() . '/' . $request->request->get('key');
         if (DataObject\Service::pathExists($intendedPath)) {
             $message = 'prevented creating object because object with same path+key already exists';
             Logger::debug($message);
@@ -864,12 +864,12 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             ]);
         }
 
-        $className = 'OpenDxp\\Model\\DataObject\\' . ucfirst($request->get('className'));
+        $className = 'OpenDxp\\Model\\DataObject\\' . ucfirst($request->request->get('className'));
         /** @var DataObject\Concrete $object */
         $object = $modelFactory->build($className);
         $object->setOmitMandatoryCheck(true); // allow to save the object although there are mandatory fields
         $classId = $request->request->get('classId');
-        if ($request->get('variantViaTree')) {
+        if ($request->request->get('variantViaTree')) {
             $parentId = $request->request->getInt('parentId');
             $parent = DataObject\Concrete::getById($parentId);
             $classId = $parent->getClass()->getId();
@@ -884,7 +884,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         $object->setUserModification($this->getAdminUser()->getId());
         $object->setPublished(false);
 
-        $objectType = $request->get('objecttype');
+        $objectType = $request->request->get('objecttype');
         if (in_array($objectType, [DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT])) {
             $object->setType($objectType);
         }
@@ -912,15 +912,15 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     {
         $success = false;
 
-        $parent = DataObject::getById((int) $request->get('parentId'));
+        $parent = DataObject::getById((int) $request->request->get('parentId'));
         if ($parent->isAllowed('create')) {
-            if (!DataObject\Service::pathExists($parent->getRealFullPath() . '/' . $request->get('key'))) {
+            if (!DataObject\Service::pathExists($parent->getRealFullPath() . '/' . $request->request->get('key'))) {
                 $folder = DataObject\Folder::create([
-                    'parentId' => $request->get('parentId'),
+                    'parentId' => $request->request->get('parentId'),
                     'creationDate' => time(),
                     'userOwner' => $this->getAdminUser()->getId(),
                     'userModification' => $this->getAdminUser()->getId(),
-                    'key' => $request->get('key'),
+                    'key' => $request->request->get('key'),
                     'published' => true,
                 ]);
 
@@ -944,14 +944,14 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
-        $type = $request->get('type');
+        $type = $request->request->get('type');
 
         if ($type === 'children') {
-            $parentObject = DataObject::getById((int) $request->get('id'));
+            $parentObject = DataObject::getById((int) $request->request->get('id'));
 
             $list = new DataObject\Listing();
             $list->setCondition('`path` LIKE ' . $list->quote($list->escapeLike($parentObject->getRealFullPath()) . '/%'));
-            $list->setLimit((int)$request->get('amount'));
+            $list->setLimit((int)$request->request->get('amount'));
             $list->setOrderKey('LENGTH(`path`)', false);
             $list->setOrder('DESC');
 
@@ -965,7 +965,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             return $this->adminJson(['success' => true, 'deleted' => $deletedItems]);
         }
-        if ($id = $request->get('id')) {
+        if ($id = $request->request->get('id')) {
             $object = DataObject::getById((int) $id);
             if ($object) {
                 if (!$object->isAllowed('delete')) {
@@ -990,10 +990,10 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/change-children-sort-by', name: 'changechildrensortby', methods: ['PUT'])]
     public function changeChildrenSortByAction(Request $request): JsonResponse
     {
-        $object = DataObject::getById((int) $request->get('id'));
+        $object = DataObject::getById((int) $request->request->get('id'));
         if ($object) {
-            $sortBy = $request->get('sortBy');
-            $sortOrder = $request->get('childrenSortOrder');
+            $sortBy = $request->request->get('sortBy');
+            $sortOrder = $request->request->get('childrenSortOrder');
             if (!\in_array($sortOrder, ['ASC', 'DESC'])) {
                 $sortOrder = 'ASC';
             }
@@ -1010,7 +1010,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     return $this->json(['success' => false, 'message' => 'Changing the sort method is only allowed for admin users']);
                 }
 
-                if ($sortBy == 'index') {
+                if ($sortBy === 'index') {
                     $this->reindexBasedOnSortOrder($object, $sortOrder);
                 }
             }
@@ -1029,9 +1029,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/update', name: 'update', methods: ['PUT'])]
     public function updateAction(Request $request): JsonResponse
     {
-        $values = $this->decodeJson($request->get('values'));
-
-        $ids = $this->decodeJson($request->get('id'));
+        $values = $this->decodeJson($request->request->get('values'));
+        $ids = $this->decodeJson($request->request->get('id'));
 
         if (is_array($ids)) {
             $return = ['success' => true];
@@ -1327,7 +1326,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             }
 
             // Mark fields that have changed as dirty
-            if ($request->get('task') !== 'autoSave' && $request->get('task') !== 'unpublish') {
+            if ($request->query->get('task') !== 'autoSave' && $request->query->get('task') !== 'unpublish') {
                 foreach ($object->getClass()->getFieldDefinitions() as $fieldName => $fieldDefinition) {
                     $getter = 'get' . ucfirst($fieldName);
                     $oldValue = $objectFromDatabase->$getter();
@@ -1372,13 +1371,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
 
         if (($request->query->get('task') === 'publish') || ($request->query->get('task') === 'unpublish')) {
-            // disabled for now: see different approach [Elements] Show users who are working on the same element #9381
-            // https://github.com/pimcore/pimcore/issues/9381
-            //            if ($data) {
-            //                if (!$this->performFieldcollectionModificationCheck($request, $object, $originalModificationDate, $data)) {
-            //                    return $this->adminJson(['success' => false, 'message' => 'Could be that someone messed around with the fieldcollection in the meantime. Please reload and try again']);
-            //                }
-            //            }
 
             $object->save();
             $treeData = $this->getTreeNodeConfig($object);
@@ -1405,14 +1397,14 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             return $this->adminJson(['success' => true]);
         }
 
-        if ($request->get('task') === 'scheduler' && $object->isAllowed('settings')) {
+        if ($request->query->get('task') === 'scheduler' && $object->isAllowed('settings')) {
             $object->saveScheduledTasks();
 
             return $this->adminJson(['success' => true]);
         }
 
         if ($object->isAllowed('save') || $object->isAllowed('publish')) {
-            $isAutoSave = $request->get('task') === 'autoSave';
+            $isAutoSave = $request->query->get('task') === 'autoSave';
             $draftData = [];
 
             if ($object->isPublished() || $isAutoSave) {
@@ -1426,7 +1418,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 $object->save();
             }
 
-            if ($request->get('task') === 'version') {
+            if ($request->query->get('task') === 'version') {
                 $object->deleteAutoSaveVersions($this->getAdminUser()->getId());
             }
 
@@ -1446,34 +1438,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
 
         throw $this->createAccessDeniedHttpException();
-    }
-
-    /**
-     * @throws Exception
-     */
-    protected function performFieldcollectionModificationCheck(Request $request, DataObject\Concrete $object, int $originalModificationDate, array $data): bool
-    {
-        $modificationDate = $request->get('modificationDate');
-        if ($modificationDate != $originalModificationDate) {
-            $fielddefinitions = $object->getClass()->getFieldDefinitions();
-            foreach ($fielddefinitions as $fd) {
-                if ($fd instanceof DataObject\ClassDefinition\Data\Fieldcollections && isset($data[$fd->getName()])) {
-                    $allowedTypes = $fd->getAllowedTypes();
-                    foreach ($allowedTypes as $type) {
-                        /** @var DataObject\Fieldcollection\Definition $fdDef */
-                        $fdDef = DataObject\Fieldcollection\Definition::getByKey($type);
-                        $childDefinitions = $fdDef->getFieldDefinitions();
-                        foreach ($childDefinitions as $childDef) {
-                            if ($childDef instanceof DataObject\ClassDefinition\Data\Localizedfields) {
-                                return false;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return true;
     }
 
     #[Route('/save-folder', name: 'savefolder', methods: ['PUT'])]
@@ -1507,7 +1471,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
     protected function assignPropertiesFromEditmode(Request $request, DataObject\AbstractObject $object): void
     {
-        if ($request->get('properties')) {
+        if ($request->request->has('properties')) {
             $properties = [];
             // assign inherited properties
             foreach ($object->getProperties() as $p) {
@@ -1516,7 +1480,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 }
             }
 
-            $propertiesData = $this->decodeJson($request->get('properties'));
+            $propertiesData = $this->decodeJson($request->request->get('properties'));
 
             if (is_array($propertiesData)) {
                 foreach ($propertiesData as $propertyName => $propertyData) {
@@ -1543,12 +1507,14 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/publish-version', name: 'publishversion', methods: ['POST'])]
     public function publishVersionAction(Request $request): JsonResponse
     {
-        $id = (int)$request->get('id');
+        $id = $request->request->getInt('id');
         $version = Model\Version::getById($id);
         $object = $version?->loadData();
+
         if (!$object) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
+
         $object = $version->loadData();
 
         $currentObject = DataObject::getById($object->getId());
@@ -1584,7 +1550,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     {
         DataObject::setDoNotRestoreKeyAndPath(true);
 
-        $id = (int)$request->get('id');
+        $id = $request->query->getInt('id');
         $version = Model\Version::getById($id);
         $object = $version?->loadData();
 
@@ -1804,9 +1770,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     #[Route('/copy-rewrite-ids', name: 'copyrewriteids', methods: ['PUT'])]
     public function copyRewriteIdsAction(Request $request): JsonResponse
     {
-        $transactionId = $request->get('transactionId');
+        $transactionId = $request->request->get('transactionId');
 
-        $idStore = Tool\Session::useBag($request->getSession(), fn (AttributeBagInterface $session) => $session->get($transactionId), 'opendxp_copy');
+        $idStore = Tool\Session::useBag($request->getSession(), static fn (AttributeBagInterface $session) => $session->get($transactionId), 'opendxp_copy');
 
         if (!array_key_exists('rewrite-stack', $idStore)) {
             $idStore['rewrite-stack'] = array_values($idStore['idMapping']);
@@ -1838,21 +1804,21 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     public function copyAction(Request $request): JsonResponse
     {
         $message = '';
-        $sourceId = (int)$request->get('sourceId');
+        $sourceId = $request->request->getInt('sourceId');
         $source = DataObject::getById($sourceId);
 
         $session = Tool\Session::getSessionBag($request->getSession(), 'opendxp_copy');
-        $sessionBag = $session->get($request->get('transactionId'));
+        $sessionBag = $session->get($request->request->get('transactionId'));
 
-        $targetId = (int)$request->get('targetId');
-        if ($request->get('targetParentId')) {
-            $sourceParent = DataObject::getById((int) $request->get('sourceParentId'));
+        $targetId = $request->request->getInt('targetId');
+        if ($request->request->has('targetParentId')) {
+            $sourceParent = DataObject::getById($request->request->getInt('sourceParentId'));
 
             // this is because the key can get the prefix "_copy" if the target does already exists
             if ($sessionBag['parentId']) {
                 $targetParent = DataObject::getById((int) $sessionBag['parentId']);
             } else {
-                $targetParent = DataObject::getById((int) $request->get('targetParentId'));
+                $targetParent = DataObject::getById($request->request->getInt('targetParentId'));
             }
 
             $targetPath = preg_replace('@^' . preg_quote($sourceParent->getRealFullPath(), '@') . '@', $targetParent . '/', $source->getRealPath());
@@ -1874,22 +1840,22 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                     $source->setPublished(false); //as latest version is used which is not published
                 }
 
-                if ($request->get('type') === 'child') {
+                if ($request->request->get('type') === 'child') {
                     $newObject = $this->_objectService->copyAsChild($target, $source);
 
                     $sessionBag['idMapping'][(int)$source->getId()] = (int)$newObject->getId();
 
                     // this is because the key can get the prefix "_copy" if the target does already exists
-                    if ($request->get('saveParentId')) {
+                    if ($request->request->get('saveParentId')) {
                         $sessionBag['parentId'] = $newObject->getId();
                     }
-                } elseif ($request->get('type') === 'replace') {
+                } elseif ($request->request->get('type') === 'replace') {
                     $concreteTarget = DataObject\Concrete::getById($target->getId());
                     $concreteSource = DataObject\Concrete::getById($source->getId());
                     $this->_objectService->copyContents($concreteTarget, $concreteSource);
                 }
 
-                $session->set($request->get('transactionId'), $sessionBag);
+                $session->set($request->request->get('transactionId'), $sessionBag);
 
                 return $this->adminJson(['success' => true, 'message' => $message]);
             }

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -43,6 +43,7 @@ use stdClass;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -162,7 +163,21 @@ class DataObjectHelperController extends AdminAbstractController
     #[Route('/grid-delete-column-config', name: 'griddeletecolumnconfig', methods: ['DELETE'])]
     public function gridDeleteColumnConfigAction(Request $request, EventDispatcherInterface $eventDispatcher, Config $config): JsonResponse
     {
-        $gridConfigId = (int)$request->get('gridConfigId');
+        $params = [
+            'id'              => $request->request->get('id'),
+            'objectId'        => $request->request->get('objectId'),
+            'name'            => $request->request->get('name'),
+            'type'            => $request->request->get('type'),
+            'types'           => $request->request->get('types'),
+            'gridtype'        => $request->request->get('gridtype'),
+            'gridConfigId'    => $request->request->get('gridConfigId'),
+            'searchType'      => $request->request->get('searchType'),
+            'noSystemColumns' => $request->query->getBoolean('no_system_columns'),
+            'noBrickColumns' => $request->query->getBoolean('no_brick_columns'),
+            'locale' => $request->getLocale(),
+        ];
+
+        $gridConfigId = (int)$request->request->get('gridConfigId');
         $gridConfig = GridConfig::getById($gridConfigId);
         $success = false;
         if ($gridConfig) {
@@ -174,7 +189,7 @@ class DataObjectHelperController extends AdminAbstractController
             $success = true;
         }
 
-        $newGridConfig = $this->doGetGridColumnConfig($request, $config, true);
+        $newGridConfig = $this->doGetGridColumnConfig($request, $params, $config, true);
         $newGridConfig['deleteSuccess'] = $success;
 
         $event = new GenericEvent($this, [
@@ -193,7 +208,20 @@ class DataObjectHelperController extends AdminAbstractController
     #[Route('/grid-get-column-config', name: 'gridgetcolumnconfig', methods: ['GET'])]
     public function gridGetColumnConfigAction(Request $request, EventDispatcherInterface $eventDispatcher, Config $config): JsonResponse
     {
-        $result = $this->doGetGridColumnConfig($request, $config);
+        $params = [
+            'id'              => $request->query->get('id'),
+            'objectId'        => $request->query->get('objectId'),
+            'name'            => $request->query->get('name'),
+            'type'            => $request->query->get('type'),
+            'types'           => $request->query->get('types'),
+            'gridtype'        => $request->query->get('gridtype'),
+            'gridConfigId'    => $request->query->get('gridConfigId'),
+            'searchType'      => $request->query->get('searchType'),
+            'noSystemColumns' => $request->query->getBoolean('no_system_columns'),
+            'noBrickColumns' => $request->query->getBoolean('no_brick_columns'),
+        ];
+
+        $result = $this->doGetGridColumnConfig($request, $params, $config);
 
         $event = new GenericEvent($this, [
             'data' => $result,
@@ -208,24 +236,24 @@ class DataObjectHelperController extends AdminAbstractController
         return $this->adminJson($result);
     }
 
-    public function doGetGridColumnConfig(Request $request, Config $config, bool $isDelete = false): array
+    private function doGetGridColumnConfig(Request $request, array $params, Config $config, bool $isDelete = false): array
     {
         $class = null;
         $fields = null;
 
-        if ($request->get('id')) {
-            $class = DataObject\ClassDefinition::getById($request->get('id'));
-        } elseif ($request->get('name')) {
-            $class = DataObject\ClassDefinition::getByName($request->get('name'));
+        if ($params['id'] !== null) {
+            $class = DataObject\ClassDefinition::getById($params['id']);
+        } elseif ($params['name'] !== null) {
+            $class = DataObject\ClassDefinition::getByName($params['name']);
         }
 
         $gridConfigId = null;
         $gridType = 'search';
-        if ($request->get('gridtype')) {
-            $gridType = $request->get('gridtype');
+        if ($params['gridtype'] !== null) {
+            $gridType = $params['gridtype'];
         }
 
-        $objectId = (int) $request->get('objectId');
+        $objectId = $params['objectId'] !== null ? (int) $params['objectId'] : 0;
 
         if ($objectId) {
             $fields = DataObject\Service::getCustomGridFieldDefinitions($class->getId(), $objectId);
@@ -246,17 +274,17 @@ class DataObjectHelperController extends AdminAbstractController
         }
 
         $types = [];
-        if ($request->get('types')) {
-            $types = explode(',', $request->get('types'));
+        if ($params['types'] !== null) {
+            $types = explode(',', $params['types']);
         }
 
         $userId = $this->getAdminUser()->getId();
 
-        $requestedGridConfigId = $isDelete ? null : $request->get('gridConfigId');
+        $requestedGridConfigId = $isDelete ? null : $params['gridConfigId'];
 
         // grid config
         $gridConfig = [];
-        $searchType = $request->get('searchType');
+        $searchType = $params['searchType'];
 
         if ((string) ($requestedGridConfigId ?? '') === '' && $class) {
             // check if there is a favourite view
@@ -313,13 +341,10 @@ class DataObjectHelperController extends AdminAbstractController
         }
 
         $localizedFields = [];
-        $objectbrickFields = [];
         if (is_array($fields)) {
             foreach ($fields as $field) {
                 if ($field instanceof DataObject\ClassDefinition\Data\Localizedfields) {
                     $localizedFields[] = $field;
-                } elseif ($field instanceof DataObject\ClassDefinition\Data\Objectbricks) {
-                    $objectbrickFields[] = $field;
                 }
             }
         }
@@ -328,10 +353,10 @@ class DataObjectHelperController extends AdminAbstractController
 
         if (empty($gridConfig)) {
             $availableFields = $this->getDefaultGridFields(
-                $request->query->getBoolean('no_system_columns'),
+                $params['noSystemColumns'],
                 $class,
                 $gridType,
-                $request->query->getBoolean('no_brick_columns'),
+                $params['noBrickColumns'],
                 $fields,
                 $context,
                 $objectId,
@@ -441,7 +466,8 @@ class DataObjectHelperController extends AdminAbstractController
                 }
             }
         }
-        usort($availableFields, fn ($a, $b) => $a['position'] <=> $b['position']);
+
+        usort($availableFields, static fn ($a, $b) => $a['position'] <=> $b['position']);
 
         $frontendLanguages = Tool\Admin::reorderWebsiteLanguages(\OpenDxp\Tool\Admin::getCurrentUser(), $config['general']['valid_languages']);
         $language = $frontendLanguages ? $frontendLanguages[0] : $request->getLocale();
@@ -657,7 +683,7 @@ class DataObjectHelperController extends AdminAbstractController
         $helperColumns = [];
         $newData = [];
         /** @var stdClass[] $data */
-        $data = json_decode($request->get('columns'));
+        $data = json_decode($request->request->get('columns'));
         foreach ($data as $item) {
             if (!empty($item->isOperator)) {
                 $itemKey = '#' . uniqid('', false);
@@ -686,8 +712,8 @@ class DataObjectHelperController extends AdminAbstractController
         $object = DataObject::getById($objectId);
 
         if ($object->isAllowed('list')) {
-            $classId = $request->get('classId');
-            $searchType = $request->get('searchType');
+            $classId = $request->request->get('classId');
+            $searchType = $request->request->get('searchType');
             $user = $this->getAdminUser();
             $db = Db::get();
             $db->executeQuery('delete from gridconfig_favourites where '
@@ -705,16 +731,16 @@ class DataObjectHelperController extends AdminAbstractController
     #[Route('/grid-mark-favourite-column-config', name: 'gridmarkfavouritecolumnconfig', methods: ['POST'])]
     public function gridMarkFavouriteColumnConfigAction(Request $request): JsonResponse
     {
-        $objectId = (int)$request->get('objectId');
+        $objectId = $request->request->getInt('objectId');
         $object = DataObject::getById($objectId);
 
         if ($object->isAllowed('list')) {
-            $classId = $request->get('classId');
-            $gridConfigId = $request->get('gridConfigId');
-            $searchType = $request->get('searchType');
-            $global = $request->get('global');
+            $classId = $request->request->get('classId');
+            $gridConfigId = $request->request->get('gridConfigId');
+            $searchType = $request->request->get('searchType');
+            $global = $request->request->get('global');
             $user = $this->getAdminUser();
-            $type = $request->get('type');
+            $type = $request->request->get('type');
 
             $favourite = new GridConfigFavourite();
             $favourite->setOwnerId($user->getId());
@@ -790,13 +816,13 @@ class DataObjectHelperController extends AdminAbstractController
 
         if ($object->isAllowed('list')) {
             try {
-                $classId = $request->get('class_id');
-                $context = $request->get('context');
+                $classId = $request->request->get('class_id');
+                $context = $request->request->get('context');
 
-                $searchType = $request->get('searchType');
+                $searchType = $request->request->get('searchType');
 
                 // grid config
-                $gridConfigData = $this->decodeJson($request->get('gridconfig'));
+                $gridConfigData = $this->decodeJson($request->request->get('gridconfig'));
                 $gridConfigData['opendxp_version'] = Version::getVersion();
                 $gridConfigData['opendxp_revision'] = Version::getRevision();
 
@@ -804,7 +830,7 @@ class DataObjectHelperController extends AdminAbstractController
 
                 unset($gridConfigData['settings']['isShared']);
 
-                $metadata = $request->get('settings');
+                $metadata = $request->request->get('settings');
                 $metadata = json_decode($metadata, true);
 
                 $gridConfigId = $metadata['gridConfigId'];
@@ -1080,10 +1106,13 @@ class DataObjectHelperController extends AdminAbstractController
     #[Route('/import-upload', name: 'importupload', methods: ['POST'])]
     public function importUploadAction(Request $request, Filesystem $filesystem): JsonResponse
     {
-        $data = file_get_contents($_FILES['Filedata']['tmp_name']);
+        /** @var UploadedFile $file */
+        $file = $request->files->get('Filedata');
+
+        $data = file_get_contents($file->getPathname());
         $data = Tool\Text::convertToUTF8($data);
 
-        $importId = $request->get('importId');
+        $importId = $request->request->get('importId');
         $importId = str_replace('..', '', $importId);
         $importFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/import_' . $importId;
         $filesystem->dumpFile($importFile, $data);
@@ -1104,7 +1133,7 @@ class DataObjectHelperController extends AdminAbstractController
 
     protected function extractLanguage(Request $request): string
     {
-        $requestedLanguage = $request->get('language');
+        $requestedLanguage = $request->request->get('language');
         if ($requestedLanguage) {
             if ($requestedLanguage !== 'default') {
                 $request->setLocale($requestedLanguage);
@@ -1166,9 +1195,9 @@ class DataObjectHelperController extends AdminAbstractController
         LocaleServiceInterface $localeService,
         EventDispatcherInterface $eventDispatcher
     ): JsonResponse {
-        $fileHandle = File::getValidFilename($request->get('fileHandle'));
-        $ids = $request->get('ids');
-        $settings = json_decode($request->get('settings'), true);
+        $fileHandle = File::getValidFilename($request->request->get('fileHandle'));
+        $ids = $request->request->all('ids');
+        $settings = json_decode($request->request->get('settings'), true);
         $delimiter = $settings['delimiter'] ?? ';';
         $header = $settings['header'] ?? 'title';
         Tool\UserTimezone::setUserTimezone($request->request->get('userTimezone'));
@@ -1178,7 +1207,7 @@ class DataObjectHelperController extends AdminAbstractController
         $enableInheritance = $settings['enableInheritance'] ?? false;
         DataObject\Concrete::setGetInheritedValues($enableInheritance);
 
-        $class = DataObject\ClassDefinition::getById($request->get('classId'));
+        $class = DataObject\ClassDefinition::getById($request->request->get('classId'));
 
         if (!$class) {
             throw new InvalidArgumentException('No class definition found');
@@ -1207,9 +1236,9 @@ class DataObjectHelperController extends AdminAbstractController
 
         $list = $beforeListExportEvent->getArgument('list');
 
-        $fields = json_decode($request->get('fields')[0], true);
+        $fields = json_decode($request->request->all('fields')[0], true);
 
-        $addTitles = (bool) $request->get('initial');
+        $addTitles = (bool) $request->request->get('initial');
 
         $requestedLanguage = $this->extractLanguage($request);
 
@@ -1217,7 +1246,7 @@ class DataObjectHelperController extends AdminAbstractController
             'source' => 'opendxp-export',
         ];
 
-        $contextFromRequest = $request->get('context');
+        $contextFromRequest = $request->request->get('context');
         if ($contextFromRequest) {
             $contextFromRequest = json_decode($contextFromRequest, true);
             $context = [...$context, ...$contextFromRequest];
@@ -1245,7 +1274,7 @@ class DataObjectHelperController extends AdminAbstractController
 
             $firstLine = true;
 
-            if ($request->get('initial') && $header === 'no_header') {
+            if ($request->request->get('initial') && $header === 'no_header') {
                 array_shift($csv);
                 $firstLine = false;
             }
@@ -1300,7 +1329,7 @@ class DataObjectHelperController extends AdminAbstractController
     public function downloadCsvFileAction(Request $request): Response
     {
         $storage = Storage::get('temp');
-        $fileHandle = File::getValidFilename($request->get('fileHandle'));
+        $fileHandle = File::getValidFilename($request->query->get('fileHandle'));
         $csvFile = $this->getCsvFile($fileHandle);
 
         try {
@@ -1360,8 +1389,8 @@ class DataObjectHelperController extends AdminAbstractController
     #[Route('/get-batch-jobs', name: 'getbatchjobs', methods: ['POST'])]
     public function getBatchJobsAction(Request $request, GridHelperService $gridHelperService): JsonResponse
     {
-        if ($request->get('language')) {
-            $request->setLocale($request->get('language'));
+        if ($request->request->get('language')) {
+            $request->setLocale($request->request->get('language'));
         }
 
         $allParams = [...$request->request->all(), ...$request->query->all()];
@@ -1534,7 +1563,7 @@ class DataObjectHelperController extends AdminAbstractController
                                             $newData = $field->appendData($existingData, $newData);
                                         }
                                         if ($remove) {
-                                            $existingData = $object->$getter($request->get('language'));
+                                            $existingData = $object->$getter($params['language']);
                                             $newData = $field->removeData($existingData, $newData);
                                         }
 

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -66,7 +66,7 @@ class DataObjectHelperController extends AdminAbstractController
         $result = [];
         if ($object) {
             $result['success'] = true;
-            $fields = $request->query->get('fields');
+            $fields = $request->query->all('fields');
             $result['fields'] = GridData\DataObject::getData($object, $fields);
         } else {
             $result['success'] = false;

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -57,16 +57,16 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Route('/object-helper', name: 'opendxp_admin_dataobject_dataobjecthelper_')]
 class DataObjectHelperController extends AdminAbstractController
 {
-    const SYSTEM_COLUMNS = ['id', 'fullpath', 'key', 'published', 'creationDate', 'modificationDate', 'filename', 'classname'];
+    public const array SYSTEM_COLUMNS = ['id', 'fullpath', 'key', 'published', 'creationDate', 'modificationDate', 'filename', 'classname'];
 
     #[Route('/load-object-data', name: 'loadobjectdata', methods: ['GET'])]
     public function loadObjectDataAction(Request $request): JsonResponse
     {
-        $object = DataObject::getById((int) $request->get('id'));
+        $object = DataObject::getById((int) $request->query->get('id'));
         $result = [];
         if ($object) {
             $result['success'] = true;
-            $fields = $request->get('fields');
+            $fields = $request->query->get('fields');
             $result['fields'] = GridData\DataObject::getData($object, $fields);
         } else {
             $result['success'] = false;
@@ -138,7 +138,7 @@ class DataObjectHelperController extends AdminAbstractController
     public function getExportConfigsAction(Request $request): JsonResponse
     {
         $result = [];
-        $classId = $request->get('classId');
+        $classId = $request->query->get('classId');
 
         $list = $this->getMyOwnGridColumnConfigs($this->getAdminUser()->getId(), $classId);
         $list = [...$list, ...$this->getSharedGridColumnConfigs($this->getAdminUser(), $classId)];
@@ -613,11 +613,7 @@ class DataObjectHelperController extends AdminAbstractController
     protected function getCalculatedColumnConfig(Request $request, array $config): mixed
     {
         try {
-            return Tool\Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($config) {
-                //otherwise create a new one
-
-                $calculatedColumn = [];
-                // note that we have to generate a new key!
+            return Tool\Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($config) {
 
                 $existingKey = $config['fieldConfig']['key'];
                 $calculatedColumnConfig['key'] = $existingKey;
@@ -634,7 +630,7 @@ class DataObjectHelperController extends AdminAbstractController
                     return $calculatedColumnConfig;
                 }
 
-                $newKey = '#' . uniqid();
+                $newKey = '#' . uniqid('', false);
                 $calculatedColumnConfig['key'] = $newKey;
 
                 // prepare a column config on the fly
@@ -664,7 +660,7 @@ class DataObjectHelperController extends AdminAbstractController
         $data = json_decode($request->get('columns'));
         foreach ($data as $item) {
             if (!empty($item->isOperator)) {
-                $itemKey = '#' . uniqid();
+                $itemKey = '#' . uniqid('', false);
 
                 $item->key = $itemKey;
                 $newData[] = $item;
@@ -674,7 +670,7 @@ class DataObjectHelperController extends AdminAbstractController
             }
         }
 
-        Tool\Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($helperColumns): void {
+        Tool\Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($helperColumns): void {
             $existingColumns = $session->get('helpercolumns', []);
             $helperColumns = [...$helperColumns, ...$existingColumns];
             $session->set('helpercolumns', $helperColumns);
@@ -755,7 +751,7 @@ class DataObjectHelperController extends AdminAbstractController
                 $favourite->delete();
             }
 
-            return $this->adminJson(['success' => true, 'spezializedConfigs' => $specializedConfigs]);
+            return $this->adminJson(['success' => true, 'specializedConfigs' => $specializedConfigs]);
         }
 
         throw $this->createAccessDeniedHttpException();
@@ -1110,7 +1106,7 @@ class DataObjectHelperController extends AdminAbstractController
     {
         $requestedLanguage = $request->get('language');
         if ($requestedLanguage) {
-            if ($requestedLanguage != 'default') {
+            if ($requestedLanguage !== 'default') {
                 $request->setLocale($requestedLanguage);
             }
         } else {
@@ -1330,7 +1326,7 @@ class DataObjectHelperController extends AdminAbstractController
     public function downloadXlsxFileAction(Request $request, GridHelperService $gridHelperService): BinaryFileResponse
     {
         $storage = Storage::get('temp');
-        $fileHandle = File::getValidFilename($request->get('fileHandle'));
+        $fileHandle = File::getValidFilename($request->query->get('fileHandle'));
         $csvFile = $this->getCsvFile($fileHandle);
 
         try {
@@ -1548,7 +1544,7 @@ class DataObjectHelperController extends AdminAbstractController
                             }
 
                             // seems to be a system field, this is actually only possible for the "published" field yet
-                            if ($name == 'published') {
+                            if ($name === 'published') {
                                 if ($value === 'false' || empty($value)) {
                                     $object->setPublished(false);
                                 } else {
@@ -1585,13 +1581,11 @@ class DataObjectHelperController extends AdminAbstractController
     #[Route('/get-available-visible-vields', name: 'getavailablevisiblefields', methods: ['GET'])]
     public function getAvailableVisibleFieldsAction(Request $request): JsonResponse
     {
-        $class = null;
-
         $classList = [];
         $classNameList = [];
 
-        if ($request->get('classes')) {
-            $classNameList = $request->get('classes');
+        if ($request->query->has('classes')) {
+            $classNameList = $request->query->get('classes');
             $classNameList = explode(',', $classNameList);
             foreach ($classNameList as $className) {
                 $class = DataObject\ClassDefinition::getByName($className);
@@ -1604,6 +1598,7 @@ class DataObjectHelperController extends AdminAbstractController
         if (!$classList) {
             return $this->adminJson(['availableFields' => []]);
         }
+
         $availableFields = [];
         foreach (self::SYSTEM_COLUMNS as $field) {
             $availableFields[] = [

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1382,14 +1382,14 @@ class DataObjectHelperController extends AdminAbstractController
         $success = true;
 
         try {
-            if ($request->get('data')) {
-                $params = $this->decodeJson($request->get('data'), true);
+            if ($request->request->has('data')) {
+                $params = $this->decodeJson($request->request->get('data'), true);
                 $object = DataObject\Concrete::getById($params['job']);
 
                 if ($object) {
                     $requestedLanguage = $params['language'];
                     if ($requestedLanguage) {
-                        if ($requestedLanguage != 'default') {
+                        if ($requestedLanguage !== 'default') {
                             $request->setLocale($requestedLanguage);
                         }
                     } else {
@@ -1408,7 +1408,7 @@ class DataObjectHelperController extends AdminAbstractController
                     $className = $object->getClassName();
                     $class = DataObject\ClassDefinition::getByName($className);
                     $value = $params['value'];
-                    if ($params['valueType'] == 'object') {
+                    if ($params['valueType'] === 'object') {
                         $value = $this->decodeJson($value);
                     }
 

--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -86,8 +86,8 @@ class QuantityValueController extends AdminAbstractController
         $list->setOrder($order);
         $list->setOrderKey($orderKey);
 
-        $list->setLimit((int)$request->query->get('limit', 25));
-        $list->setOffset((int)$request->query->get('start', 0));
+        $list->setLimit((int)$request->query->get('limit', '25'));
+        $list->setOffset((int)$request->query->get('start', '0'));
 
         $condition = '1 = 1';
         if ($request->query->get('filter')) {

--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -73,8 +73,7 @@ class QuantityValueController extends AdminAbstractController
         $order = ['ASC', 'ASC', 'ASC'];
         $orderKey = ['baseunit', 'factor', 'abbreviation'];
 
-        $allParams = [...$request->request->all(), ...$request->query->all()];
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($allParams);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
 
         // Prepend user-requested sorting settings but keep the others to keep secondary order of quantity values in respective order
         if ($sortingSettings['orderKey']) {
@@ -87,18 +86,18 @@ class QuantityValueController extends AdminAbstractController
         $list->setOrder($order);
         $list->setOrderKey($orderKey);
 
-        $list->setLimit((int)$request->get('limit', 25));
-        $list->setOffset((int)$request->get('start', 0));
+        $list->setLimit((int)$request->query->get('limit', 25));
+        $list->setOffset((int)$request->query->get('start', 0));
 
         $condition = '1 = 1';
-        if ($request->get('filter')) {
-            $filterString = $request->get('filter');
+        if ($request->query->get('filter')) {
+            $filterString = $request->query->get('filter');
             $filters = json_decode($filterString);
             $db = \OpenDxp\Db::get();
             foreach ($filters as $f) {
-                if ($f->type == 'string') {
+                if ($f->type === 'string') {
                     $condition .= ' AND ' . $db->quoteIdentifier($f->property) . ' LIKE ' . $db->quote('%' . $f->value . '%');
-                } elseif ($f->type == 'numeric') {
+                } elseif ($f->type === 'numeric') {
                     $operator = $this->getOperator($f->comparison);
                     $condition .= ' AND ' . $db->quoteIdentifier($f->property) . ' ' . $operator . ' ' . $db->quote($f->value);
                 }
@@ -122,9 +121,9 @@ class QuantityValueController extends AdminAbstractController
     {
         $this->checkPermission('quantityValueUnits');
 
-        if ($request->get('data')) {
-            if ($request->get('xaction') == 'destroy') {
-                $data = json_decode($request->get('data'), true);
+        if ($request->request->has('data')) {
+            if ($request->query->get('xaction') === 'destroy') {
+                $data = json_decode($request->request->get('data'), true);
                 $id = $data['id'];
                 $unit = \OpenDxp\Model\DataObject\QuantityValue\Unit::getById($id);
                 if (!empty($unit)) {
@@ -135,8 +134,8 @@ class QuantityValueController extends AdminAbstractController
 
                 throw new Exception('Unit with id ' . $id . ' not found.');
             }
-            if ($request->get('xaction') == 'update') {
-                $data = json_decode($request->get('data'), true);
+            if ($request->query->get('xaction') === 'update') {
+                $data = json_decode($request->request->get('data'), true);
                 $unit = Unit::getById($data['id']);
                 if (!empty($unit)) {
                     if (($data['baseunit'] ?? null) == -1) {
@@ -150,8 +149,8 @@ class QuantityValueController extends AdminAbstractController
 
                 throw new Exception('Unit with id ' . $data['id'] . ' not found.');
             }
-            if ($request->get('xaction') == 'create') {
-                $data = json_decode($request->get('data'), true);
+            if ($request->query->get('xaction') === 'create') {
+                $data = json_decode($request->request->get('data'), true);
                 if (isset($data['baseunit']) && $data['baseunit'] === -1) {
                     $data['baseunit'] = null;
                 }
@@ -190,8 +189,8 @@ class QuantityValueController extends AdminAbstractController
         $list = new Unit\Listing();
         $list->setOrderKey(['baseunit', 'factor', 'abbreviation']);
         $list->setOrder(['ASC', 'ASC', 'ASC']);
-        if ($request->get('filter')) {
-            $array = explode(',', $request->get('filter'));
+        if ($request->query->get('filter')) {
+            $array = explode(',', $request->query->get('filter'));
             $quotedArray = [];
             $db = \OpenDxp\Db::get();
             foreach ($array as $a) {
@@ -227,8 +226,8 @@ class QuantityValueController extends AdminAbstractController
     {
         $this->checkPermission('objects');
 
-        $fromUnitId = $request->get('fromUnit');
-        $toUnitId = $request->get('toUnit');
+        $fromUnitId = $request->query->get('fromUnit');
+        $toUnitId = $request->query->get('toUnit');
 
         $fromUnit = Unit::getById($fromUnitId);
         $toUnit = Unit::getById($toUnitId);
@@ -237,7 +236,7 @@ class QuantityValueController extends AdminAbstractController
         }
 
         try {
-            $convertedValue = $conversionService->convert(new QuantityValue($request->get('value'), $fromUnit), $toUnit);
+            $convertedValue = $conversionService->convert(new QuantityValue($request->query->get('value'), $fromUnit), $toUnit);
         } catch (Exception) {
             return $this->adminJson(['success' => false]);
         }
@@ -250,7 +249,7 @@ class QuantityValueController extends AdminAbstractController
     {
         $this->checkPermission('objects');
 
-        $unitId = $request->get('unit');
+        $unitId = $request->query->get('unit');
 
         $fromUnit = Unit::getById($unitId);
         if (!$fromUnit instanceof Unit) {
@@ -264,7 +263,7 @@ class QuantityValueController extends AdminAbstractController
         $convertedValues = [];
         foreach ($units->getUnits() as $targetUnit) {
             try {
-                $convertedValue = $conversionService->convert(new QuantityValue($request->get('value'), $fromUnit), $targetUnit);
+                $convertedValue = $conversionService->convert(new QuantityValue($request->query->get('value'), $fromUnit), $targetUnit);
 
                 $convertedValues[] = ['unit' => $targetUnit->getAbbreviation(), 'unitName' => $targetUnit->getLongname(), 'value' => round($convertedValue->getValue(), 4)];
             } catch (Exception $e) {
@@ -272,6 +271,10 @@ class QuantityValueController extends AdminAbstractController
             }
         }
 
-        return $this->adminJson(['value' => $request->get('value'), 'fromUnit' => $fromUnit->getAbbreviation(), 'values' => $convertedValues, 'success' => true]);
+        return $this->adminJson([
+            'value' => $request->query->get('value'),
+            'fromUnit' => $fromUnit->getAbbreviation(),
+            'values' => $convertedValues, 'success' => true]
+        );
     }
 }

--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -23,6 +23,7 @@ use OpenDxp\Model\DataObject\QuantityValue\Service as QuantityValueService;
 use OpenDxp\Model\DataObject\QuantityValue\Unit;
 use OpenDxp\Model\DataObject\QuantityValue\UnitConversionService;
 use OpenDxp\Model\Translation;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -41,7 +42,10 @@ class QuantityValueController extends AdminAbstractController
     #[Route('/unit-import', name: 'unitimport', methods: ['POST', 'PUT'])]
     public function unitImportAction(Request $request): JsonResponse
     {
-        $json = file_get_contents($_FILES['Filedata']['tmp_name']);
+        /** @var UploadedFile $tmpName */
+        $uploadFile = $request->files->get('Filedata');
+
+        $json = file_get_contents($uploadFile->getPathname());
         $success = $this->service->importDefinitionFromJson($json);
         $response = $this->adminJson(['success' => $success]);
         $response->headers->set('Content-Type', 'text/html');

--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -42,7 +42,7 @@ class QuantityValueController extends AdminAbstractController
     #[Route('/unit-import', name: 'unitimport', methods: ['POST', 'PUT'])]
     public function unitImportAction(Request $request): JsonResponse
     {
-        /** @var UploadedFile $tmpName */
+        /** @var UploadedFile $uploadFile */
         $uploadFile = $request->files->get('Filedata');
 
         $json = file_get_contents($uploadFile->getPathname());

--- a/src/Controller/Admin/DataObject/VariantsController.php
+++ b/src/Controller/Admin/DataObject/VariantsController.php
@@ -48,7 +48,7 @@ class VariantsController extends AdminAbstractController
     /**
      * @throws Exception
      */
-    #[Route('/get-variants', name: 'getvariants', methods: ['GET', 'POST'])]
+    #[Route('/get-variants', name: 'getvariants', methods: ['POST'])]
     public function getVariantsAction(
         Request $request,
         EventDispatcherInterface $eventDispatcher,
@@ -56,9 +56,11 @@ class VariantsController extends AdminAbstractController
         LocaleServiceInterface $localeService,
         CsrfProtectionHandler $csrfProtection
     ): JsonResponse {
-        $parentObject = DataObject\Concrete::getById((int) $request->get('objectId'));
-        if (empty($parentObject)) {
-            throw new Exception('No Object found with id ' . $request->get('objectId'));
+
+        $parentObject = DataObject\Concrete::getById((int) $request->request->get('objectId'));
+
+        if ($parentObject === null) {
+            throw new Exception('No Object found with id ' . $request->request->get('objectId'));
         }
 
         if (!$parentObject->isAllowed('view')) {
@@ -66,6 +68,7 @@ class VariantsController extends AdminAbstractController
         }
 
         $allParams = [...$request->request->all(), ...$request->query->all()];
+
         $allParams['folderId'] = $parentObject->getId();
         $allParams['classId'] = $parentObject->getClassId();
 

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -92,7 +92,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/get-data-by-id', name: 'opendxp_admin_document_document_getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
-        $document = Document::getById((int) $request->get('id'));
+        $document = Document::getById((int) $request->query->get('id'));
 
         if (!$document) {
             throw $this->createNotFoundException('Document not found');
@@ -135,7 +135,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     {
         $allParams = [...$request->request->all(), ...$request->query->all()];
 
-        $filter = $request->get('filter');
+        $filter = $request->query->get('filter');
         $limit = (int)($allParams['limit'] ?? 100000000);
         $offset = (int)($allParams['start'] ?? 0);
 
@@ -608,11 +608,11 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/doc-types', name: 'opendxp_admin_document_document_doctypes', methods: ['PUT', 'POST', 'DELETE'])]
     public function docTypesAction(Request $request): JsonResponse
     {
-        if ($request->get('data')) {
+        if ($request->request->get('data')) {
             $this->checkPermission('document_types');
 
-            $data = $this->decodeJson($request->get('data'));
-            if ($request->get('xaction') === 'destroy') {
+            $data = $this->decodeJson($request->request->get('data'));
+            if ($request->query->get('xaction') === 'destroy') {
                 $type = Document\DocType::getById($data['id']);
                 if (!$type->isWriteable()) {
                     throw new ConfigWriteException();
@@ -621,7 +621,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
                 return $this->adminJson(['success' => true, 'data' => []]);
             }
-            if ($request->get('xaction') === 'update') {
+            if ($request->query->get('xaction') === 'update') {
                 // save type
                 $type = Document\DocType::getById($data['id']);
                 if (!$type->isWriteable()) {
@@ -635,7 +635,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 return $this->adminJson(['data' => $responseData, 'success' => true]);
             }
 
-            if ($request->get('xaction') === 'create') {
+            if ($request->query->get('xaction') === 'create') {
                 if (!(new DocType())->isWriteable()) {
                     throw new ConfigWriteException();
                 }

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -243,10 +243,10 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $errorMessage = '';
 
         // check for permission
-        $parentDocument = Document::getById((int)$request->get('parentId'));
+        $parentDocument = Document::getById($request->request->getInt('parentId'));
         $document = null;
         if ($parentDocument->isAllowed('create')) {
-            $intendedPath = $parentDocument->getRealFullPath() . '/' . $request->get('key');
+            $intendedPath = $parentDocument->getRealFullPath() . '/' . $request->request->get('key');
 
             if (!Document\Service::pathExists($intendedPath)) {
                 $createValues = [
@@ -255,34 +255,34 @@ class DocumentController extends ElementControllerBase implements KernelControll
                     'published' => false,
                 ];
 
-                $createValues['key'] = Service::getValidKey($request->get('key'), 'document');
+                $createValues['key'] = Service::getValidKey($request->request->get('key'), 'document');
 
                 // check for a docType
-                $docType = Document\DocType::getById($request->get('docTypeId', ''));
+                $docType = Document\DocType::getById($request->request->get('docTypeId', ''));
 
                 if ($docType) {
                     $createValues['template'] = $docType->getTemplate();
                     $createValues['controller'] = $docType->getController();
                     $createValues['staticGeneratorEnabled'] = $docType->getStaticGeneratorEnabled();
-                } elseif ($translationsBaseDocumentId = $request->get('translationsBaseDocument')) {
+                } elseif ($translationsBaseDocumentId = $request->request->get('translationsBaseDocument')) {
                     $translationsBaseDocument = Document::getById((int) $translationsBaseDocumentId);
                     if ($translationsBaseDocument instanceof Document\PageSnippet) {
                         $createValues['template'] = $translationsBaseDocument->getTemplate();
                         $createValues['controller'] = $translationsBaseDocument->getController();
                     }
-                } elseif (in_array($request->get('type'), ['page', 'snippet', 'email'])) {
+                } elseif (in_array($request->request->get('type'), ['page', 'snippet', 'email'])) {
                     $createValues['controller'] = $this->getParameter('opendxp.documents.default_controller');
                 }
 
-                if ($request->get('inheritanceSource')) {
-                    $createValues['contentMainDocumentId'] = $request->get('inheritanceSource');
+                if ($request->request->has('inheritanceSource')) {
+                    $createValues['contentMainDocumentId'] = $request->request->get('inheritanceSource');
                 }
 
-                switch ($request->get('type')) {
+                switch ($request->request->get('type')) {
                     case 'page':
                         $document = Document\Page::create($parentDocument->getId(), $createValues, false);
-                        $document->setTitle($request->get('title'));
-                        $document->setProperty('navigation_name', 'text', $request->get('name'), false, false);
+                        $document->setTitle($request->request->get('title'));
+                        $document->setProperty('navigation_name', 'text', $request->request->get('name'), false, false);
                         $document->save();
                         $success = true;
 
@@ -320,7 +320,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
                         break;
                     default:
-                        $classname = OpenDxp::getContainer()->get('opendxp.class.resolver.document')->resolve($request->get('type'));
+                        $classname = OpenDxp::getContainer()->get('opendxp.class.resolver.document')->resolve($request->request->get('type'));
 
                         if (Tool::classExists($classname)) {
                             $document = $classname::create($parentDocument->getId(), $createValues);
@@ -335,7 +335,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
                             break;
                         }
 
-                        Logger::debug("Unknown document type, can't add [ " . $request->get('type') . ' ] ');
+                        Logger::debug("Unknown document type, can't add [ " . $request->request->get('type') . ' ] ');
 
                         break;
                 }
@@ -349,13 +349,13 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }
 
         if ($success && $document instanceof Document) {
-            if ($translationsBaseDocumentId = $request->get('translationsBaseDocument')) {
+            if ($translationsBaseDocumentId = $request->request->get('translationsBaseDocument')) {
                 $translationsBaseDocument = Document::getById((int) $translationsBaseDocumentId);
 
                 $properties = $translationsBaseDocument->getProperties();
                 $properties = [...$properties, ...$document->getProperties()];
                 $document->setProperties($properties);
-                $document->setProperty('language', 'text', $request->get('language'), false, true);
+                $document->setProperty('language', 'text', $request->request->get('language'), false, true);
                 $document->save();
 
                 $service = new Document\Service();
@@ -378,14 +378,14 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/delete', name: 'opendxp_admin_document_document_delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
-        $type = $request->get('type');
+        $type = $request->request->get('type');
 
         if ($type === 'children') {
-            $parentDocument = Document::getById((int) $request->get('id'));
+            $parentDocument = Document::getById((int) $request->request->get('id'));
 
             $list = new Document\Listing();
             $list->setCondition('`path` LIKE ?', [$list->escapeLike($parentDocument->getRealFullPath()) . '/%']);
-            $list->setLimit((int)$request->get('amount'));
+            $list->setLimit((int)$request->request->get('amount'));
             $list->setOrderKey('LENGTH(`path`)', false);
             $list->setOrder('DESC');
 
@@ -401,7 +401,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
             return $this->adminJson(['success' => true, 'deleted' => $deletedItems]);
         }
-        if ($id = $request->get('id')) {
+
+        if ($id = $request->request->get('id')) {
             $document = Document::getById((int) $id);
             if ($document && $document->isAllowed('delete')) {
                 try {
@@ -432,7 +433,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $data = ['success' => false];
         $allowUpdate = true;
 
-        $document = Document::getById((int) $request->get('id'));
+        $document = Document::getById((int) $request->request->get('id'));
 
         $oldPath = $document->getDao()->getCurrentFullPath();
         $oldDocument = Document::getById($document->getId(), ['force' => true]);
@@ -454,7 +455,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
         if ($document->isAllowed('settings')) {
             // if the position is changed the path must be changed || also from the children
-            if ($parentId = $request->get('parentId')) {
+            if ($parentId = $request->request->get('parentId')) {
                 $parentDocument = Document::getById((int) $parentId);
 
                 //check if parent is changed
@@ -482,9 +483,9 @@ class DocumentController extends ElementControllerBase implements KernelControll
             }
 
             if ($allowUpdate) {
-                $blockedVars = ['controller', 'action', 'module'];
+                $blockedVars = ['id', 'controller', 'action', 'module'];
 
-                if (!$document->isAllowed('rename') && $request->get('key')) {
+                if (!$document->isAllowed('rename') && $request->request->get('key')) {
                     $blockedVars[] = 'key';
                     Logger::debug('prevented renaming document because of missing permissions ');
                 }
@@ -502,8 +503,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 try {
                     $document->save();
 
-                    if ($request->get('index') !== null) {
-                        $this->updateIndexesOfDocumentSiblings($document, $request->get('index'));
+                    if ($request->request->get('index') !== null) {
+                        $this->updateIndexesOfDocumentSiblings($document, $request->request->get('index'));
                     }
 
                     $data = [
@@ -523,10 +524,10 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
                 return $this->adminJson(['success' => false, 'message' => $msg]);
             }
-        } elseif ($document->isAllowed('rename') && $request->get('key')) {
+        } elseif ($document->isAllowed('rename') && $request->request->get('key')) {
             //just rename
             try {
-                $document->setKey($request->get('key'));
+                $document->setKey($request->request->get('key'));
                 $document->setUserModification($this->getAdminUser()->getId());
                 $document->save();
                 $data = [
@@ -680,7 +681,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/version-to-session', name: 'opendxp_admin_document_document_versiontosession', methods: ['POST'])]
     public function versionToSessionAction(Request $request): Response
     {
-        $id = (int)$request->get('id');
+        $id = $request->request->getInt('id');
         $version = Version::getById($id);
         $document = $version?->loadData();
         if (!$document) {
@@ -696,7 +697,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     {
         $this->versionToSessionAction($request);
 
-        $id = (int)$request->get('id');
+        $id = $request->request->getInt('id');
         $version = Version::getById($id);
         $document = $version?->loadData();
         if (!$document) {
@@ -764,7 +765,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/remove-site', name: 'opendxp_admin_document_document_removesite', methods: ['DELETE'])]
     public function removeSiteAction(Request $request): JsonResponse
     {
-        $site = Site::getByRootId((int)$request->get('id'));
+        $site = Site::getByRootId($request->request->getInt('id'));
         $site->delete();
 
         return $this->adminJson(['success' => true]);
@@ -781,7 +782,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }, 'opendxp_copy');
 
         if ($request->query->get('type') === 'recursive' || $request->query->get('type') === 'recursive-update-references') {
-            $document = Document::getById((int) $request->get('sourceId'));
+            $document = Document::getById((int) $request->query->get('sourceId'));
 
             // first of all the new parent
             $pasteJobs[] = [[
@@ -815,11 +816,11 @@ class DocumentController extends ElementControllerBase implements KernelControll
                             'method' => 'POST',
                             'params' => [
                                 'sourceId' => $id,
-                                'targetParentId' => $request->get('targetId'),
-                                'sourceParentId' => $request->get('sourceId'),
+                                'targetParentId' => $request->query->get('targetId'),
+                                'sourceParentId' => $request->query->get('sourceId'),
                                 'type' => 'child',
-                                'language' => $request->get('language'),
-                                'enableInheritance' => $request->get('enableInheritance'),
+                                'language' => $request->query->get('language'),
+                                'enableInheritance' => $request->query->get('enableInheritance'),
                                 'transactionId' => $transactionId,
                             ],
                         ]];
@@ -866,7 +867,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/copy-rewrite-ids', name: 'opendxp_admin_document_document_copyrewriteids', methods: ['PUT'])]
     public function copyRewriteIdsAction(Request $request): JsonResponse
     {
-        $transactionId = $request->get('transactionId');
+        $transactionId = $request->request->get('transactionId');
 
         $idStore = Session::useBag($request->getSession(), static fn (AttributeBagInterface $session) => $session->get($transactionId), 'opendxp_copy');
 
@@ -882,7 +883,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
             $rewriteConfig = ['document' => $idStore['idMapping']];
 
             $document = Document\Service::rewriteIds($document, $rewriteConfig, [
-                'enableInheritance' => $request->get('enableInheritance') === 'true',
+                'enableInheritance' => $request->request->get('enableInheritance') === 'true',
             ]);
 
             $document->setUserModification($this->getAdminUser()->getId());
@@ -890,7 +891,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }
 
         // write the store back to the session
-        Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($transactionId, $idStore): void {
+        Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($transactionId, $idStore): void {
             $session->set($transactionId, $idStore);
         }, 'opendxp_copy');
 
@@ -904,22 +905,22 @@ class DocumentController extends ElementControllerBase implements KernelControll
     public function copyAction(Request $request): JsonResponse
     {
         $success = false;
-        $sourceId = (int)$request->get('sourceId');
+        $sourceId = (int)$request->request->get('sourceId');
         $source = Document::getById($sourceId);
         $session = Session::getSessionBag($request->getSession(), 'opendxp_copy');
 
-        $targetId = (int)$request->get('targetId');
+        $targetId = (int)$request->request->get('targetId');
 
-        $sessionBag = $session->get($request->get('transactionId'));
+        $sessionBag = $session->get($request->request->get('transactionId'));
 
-        if ($request->get('targetParentId')) {
-            $sourceParent = Document::getById((int) $request->get('sourceParentId'));
+        if ($request->request->get('targetParentId')) {
+            $sourceParent = Document::getById((int) $request->request->get('sourceParentId'));
 
             // this is because the key can get the prefix "_copy" if the target does already exists
             if ($sessionBag['parentId']) {
                 $targetParent = Document::getById((int) $sessionBag['parentId']);
             } else {
-                $targetParent = Document::getById((int) $request->get('targetParentId'));
+                $targetParent = Document::getById((int) $request->request->get('targetParentId'));
             }
 
             $targetPath = preg_replace('@^' . $sourceParent->getRealFullPath() . '@', $targetParent . '/', $source->getRealPath());
@@ -930,32 +931,32 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
         if ($target instanceof Document) {
             if ($target->isAllowed('create')) {
-                if ($source != null) {
+                if ($source !== null) {
                     if ($source instanceof Document\PageSnippet && $latestVersion = $source->getLatestVersion()) {
                         $source = $latestVersion->loadData();
                         $source->setPublished(false); //as latest version is used which is not published
                     }
 
-                    if ($request->get('type') === 'child') {
-                        $enableInheritance = $request->get('enableInheritance') === 'true';
+                    if ($request->request->get('type') === 'child') {
+                        $enableInheritance = $request->request->get('enableInheritance') === 'true';
 
                         $language = (string) $request->request->get('language') ?: null;
                         if ($language && !Tool::isValidLanguage($language)) {
                             throw new BadRequestHttpException('Invalid language: ' . $language);
                         }
 
-                        $resetIndex = $request->get('resetIndex') === 'true';
+                        $resetIndex = $request->request->get('resetIndex') === 'true';
 
                         $newDocument = $this->_documentService->copyAsChild($target, $source, $enableInheritance, $resetIndex, $language);
 
                         $sessionBag['idMapping'][(int)$source->getId()] = (int)$newDocument->getId();
 
                         // this is because the key can get the prefix "_copy" if the target does already exists
-                        if ($request->get('saveParentId')) {
+                        if ($request->request->get('saveParentId')) {
                             $sessionBag['parentId'] = $newDocument->getId();
                         }
-                        $session->set($request->get('transactionId'), $sessionBag);
-                    } elseif ($request->get('type') === 'replace') {
+                        $session->set($request->request->get('transactionId'), $sessionBag);
+                    } elseif ($request->request->get('type') === 'replace') {
                         $this->_documentService->copyContents($target, $source);
                     }
 
@@ -1059,7 +1060,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
     public function diffVersionsHtmlAction(Request $request): BinaryFileResponse
     {
-        $file = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/' . basename($request->get('id'));
+        $file = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/' . basename($request->query->get('id'));
         if (file_exists($file)) {
             return new BinaryFileResponse($file);
         }
@@ -1191,12 +1192,12 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/convert', name: 'opendxp_admin_document_document_convert', methods: ['PUT'])]
     public function convertAction(Request $request): JsonResponse
     {
-        $document = Document::getById((int) $request->get('id'));
+        $document = Document::getById((int) $request->request->get('id'));
         if (!$document) {
             throw $this->createNotFoundException();
         }
 
-        $type = $request->get('type');
+        $type = $request->request->get('type');
         $class = '\\OpenDxp\\Model\\Document\\' . ucfirst($type);
         if (Tool::classExists($class)) {
             $new = new $class;
@@ -1254,8 +1255,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/translation-add', name: 'opendxp_admin_document_document_translationadd', methods: ['POST'])]
     public function translationAddAction(Request $request): JsonResponse
     {
-        $sourceDocument = Document::getById((int) $request->get('sourceId'));
-        $targetDocument = Document::getByPath($request->get('targetPath'));
+        $sourceDocument = Document::getById((int) $request->request->get('sourceId'));
+        $targetDocument = Document::getByPath($request->request->get('targetPath'));
 
         if ($sourceDocument && $targetDocument) {
             if (empty($sourceDocument->getProperty('language'))) {
@@ -1281,8 +1282,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/translation-remove', name: 'opendxp_admin_document_document_translationremove', methods: ['DELETE'])]
     public function translationRemoveAction(Request $request): JsonResponse
     {
-        $sourceDocument = Document::getById((int) $request->get('sourceId'));
-        $targetDocument = Document::getById((int) $request->get('targetId'));
+        $sourceDocument = Document::getById($request->request->getInt('sourceId'));
+        $targetDocument = Document::getById($request->request->getInt('targetId'));
         if ($sourceDocument && $targetDocument) {
             $service = new Document\Service;
             $service->removeTranslationLink($sourceDocument, $targetDocument);

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -133,7 +133,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/tree-get-children-by-id', name: 'opendxp_admin_document_document_treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
-        $allParams = [...$request->request->all(), ...$request->query->all()];
+        $allParams = $request->query->all();
 
         $filter = $request->query->get('filter');
         $limit = (int)($allParams['limit'] ?? 100000000);
@@ -218,6 +218,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $event = new GenericEvent($this, [
             'documents' => $documents,
         ]);
+
         $eventDispatcher->dispatch($event, AdminEvents::DOCUMENT_TREE_GET_CHILDREN_BY_ID_PRE_SEND_DATA);
         $documents = $event->getArgument('documents');
 
@@ -227,8 +228,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 'limit' => $limit,
                 'total' => $document->getChildAmount($this->getAdminUser()),
                 'nodes' => $documents,
-                'filter' => $request->get('filter') ?: '',
-                'inSearch' => (int)$request->get('inSearch'),
+                'filter' => $request->query->get('filter') ?: '',
+                'inSearch' => (int)$request->query->get('inSearch'),
             ]);
         }
 
@@ -332,9 +333,9 @@ class DocumentController extends ElementControllerBase implements KernelControll
                             }
 
                             break;
-                        } else {
-                            Logger::debug("Unknown document type, can't add [ " . $request->get('type') . ' ] ');
                         }
+
+                        Logger::debug("Unknown document type, can't add [ " . $request->get('type') . ' ] ');
 
                         break;
                 }
@@ -661,7 +662,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     public function getDocTypesAction(Request $request): JsonResponse
     {
         $list = new DocType\Listing();
-        if ($type = $request->get('type')) {
+        if ($type = $request->query->get('type')) {
             if (!Document\Service::isValidType($type)) {
                 throw new BadRequestHttpException('Invalid type: ' . $type);
             }
@@ -775,11 +776,11 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $transactionId = time();
         $pasteJobs = [];
 
-        Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($transactionId): void {
+        Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($transactionId): void {
             $session->set((string) $transactionId, ['idMapping' => []]);
         }, 'opendxp_copy');
 
-        if ($request->get('type') == 'recursive' || $request->get('type') == 'recursive-update-references') {
+        if ($request->query->get('type') === 'recursive' || $request->query->get('type') === 'recursive-update-references') {
             $document = Document::getById((int) $request->get('sourceId'));
 
             // first of all the new parent
@@ -787,11 +788,11 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 'url' => $this->generateUrl('opendxp_admin_document_document_copy'),
                 'method' => 'POST',
                 'params' => [
-                    'sourceId' => $request->get('sourceId'),
-                    'targetId' => $request->get('targetId'),
+                    'sourceId' => $request->query->get('sourceId'),
+                    'targetId' => $request->query->get('targetId'),
                     'type' => 'child',
-                    'language' => $request->get('language'),
-                    'enableInheritance' => $request->get('enableInheritance'),
+                    'language' => $request->query->get('language'),
+                    'enableInheritance' => $request->query->get('enableInheritance'),
                     'transactionId' => $transactionId,
                     'saveParentId' => true,
                     'resetIndex' => true,
@@ -827,32 +828,32 @@ class DocumentController extends ElementControllerBase implements KernelControll
             }
 
             // add id-rewrite steps
-            if ($request->get('type') == 'recursive-update-references') {
+            if ($request->query->get('type') === 'recursive-update-references') {
                 for ($i = 0; $i < (count($childIds) + 1); $i++) {
                     $pasteJobs[] = [[
                         'url' => $this->generateUrl('opendxp_admin_document_document_copyrewriteids'),
                         'method' => 'PUT',
                         'params' => [
                             'transactionId' => $transactionId,
-                            'enableInheritance' => $request->get('enableInheritance'),
-                            '_dc' => uniqid(),
+                            'enableInheritance' => $request->query->get('enableInheritance'),
+                            '_dc' => uniqid('', false),
                         ],
                     ]];
                 }
             }
-        } elseif ($request->get('type') == 'child' || $request->get('type') == 'replace') {
+        } elseif ($request->query->get('type') === 'child' || $request->query->get('type') === 'replace') {
             // the object itself is the last one
             $pasteJobs[] = [[
                 'url' => $this->generateUrl('opendxp_admin_document_document_copy'),
                 'method' => 'POST',
                 'params' => [
-                    'sourceId' => $request->get('sourceId'),
-                    'targetId' => $request->get('targetId'),
-                    'type' => $request->get('type'),
-                    'language' => $request->get('language'),
-                    'enableInheritance' => $request->get('enableInheritance'),
+                    'sourceId' => $request->query->get('sourceId'),
+                    'targetId' => $request->query->get('targetId'),
+                    'type' => $request->query->get('type'),
+                    'language' => $request->query->get('language'),
+                    'enableInheritance' => $request->query->get('enableInheritance'),
                     'transactionId' => $transactionId,
-                    'resetIndex' => ($request->get('type') == 'child'),
+                    'resetIndex' => ($request->query->get('type') === 'child'),
                 ],
             ]];
         }
@@ -867,7 +868,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     {
         $transactionId = $request->get('transactionId');
 
-        $idStore = Session::useBag($request->getSession(), fn (AttributeBagInterface $session) => $session->get($transactionId), 'opendxp_copy');
+        $idStore = Session::useBag($request->getSession(), static fn (AttributeBagInterface $session) => $session->get($transactionId), 'opendxp_copy');
 
         if (!array_key_exists('rewrite-stack', $idStore)) {
             $idStore['rewrite-stack'] = array_values($idStore['idMapping']);
@@ -881,7 +882,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
             $rewriteConfig = ['document' => $idStore['idMapping']];
 
             $document = Document\Service::rewriteIds($document, $rewriteConfig, [
-                'enableInheritance' => $request->get('enableInheritance') == 'true',
+                'enableInheritance' => $request->get('enableInheritance') === 'true',
             ]);
 
             $document->setUserModification($this->getAdminUser()->getId());
@@ -935,15 +936,15 @@ class DocumentController extends ElementControllerBase implements KernelControll
                         $source->setPublished(false); //as latest version is used which is not published
                     }
 
-                    if ($request->get('type') == 'child') {
-                        $enableInheritance = $request->get('enableInheritance') == 'true';
+                    if ($request->get('type') === 'child') {
+                        $enableInheritance = $request->get('enableInheritance') === 'true';
 
                         $language = (string) $request->request->get('language') ?: null;
                         if ($language && !Tool::isValidLanguage($language)) {
                             throw new BadRequestHttpException('Invalid language: ' . $language);
                         }
 
-                        $resetIndex = $request->get('resetIndex') == 'true';
+                        $resetIndex = $request->get('resetIndex') === 'true';
 
                         $newDocument = $this->_documentService->copyAsChild($target, $source, $enableInheritance, $resetIndex, $language);
 
@@ -954,7 +955,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
                             $sessionBag['parentId'] = $newDocument->getId();
                         }
                         $session->set($request->get('transactionId'), $sessionBag);
-                    } elseif ($request->get('type') == 'replace') {
+                    } elseif ($request->get('type') === 'replace') {
                         $this->_documentService->copyContents($target, $source);
                     }
 
@@ -1069,7 +1070,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     #[Route('/get-id-for-path', name: 'opendxp_admin_document_document_getidforpath', methods: ['GET'])]
     public function getIdForPathAction(Request $request): JsonResponse
     {
-        if ($doc = Document::getByPath($request->get('path'))) {
+        if ($doc = Document::getByPath($request->query->get('path'))) {
             return $this->adminJson([
                 'id' => $doc->getId(),
                 'type' => $doc->getType(),
@@ -1084,7 +1085,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     {
         $document = Document::getById((int) $request->query->get('node'));
 
-        $languages = explode(',', $request->get('languages'));
+        $languages = explode(',', $request->query->get('languages'));
 
         $result = [];
         foreach ($document->getChildren() as $child) {
@@ -1211,7 +1212,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
                 $new->setValue($name, $value);
             }
 
-            if ($type == 'hardlink' || $type == 'folder') {
+            if ($type === 'hardlink' || $type === 'folder') {
                 // remove navigation settings
                 foreach (['name', 'title', 'target', 'exclude', 'class', 'anchor', 'parameters', 'relation', 'accesskey', 'tabindex'] as $propertyName) {
                     $new->removeProperty('navigation_' . $propertyName);
@@ -1231,22 +1232,22 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $success = false;
         $targetDocument = null;
 
-        $document = Document::getById((int) $request->get('id'));
+        $document = Document::getById((int) $request->query->get('id'));
         if ($document) {
             $service = new Document\Service();
             $document = $document->getId() === 1 ? $document : $document->getParent();
 
             $translations = $service->getTranslations($document);
-            if (isset($translations[$request->get('language')])) {
-                $targetDocument = Document::getById($translations[$request->get('language')]);
+            if (isset($translations[$request->query->get('language')])) {
+                $targetDocument = Document::getById($translations[$request->query->get('language')]);
                 $success = true;
             }
         }
 
         return $this->adminJson([
             'success' => $success,
-            'targetPath' => $targetDocument ? $targetDocument->getRealFullPath() : null,
-            'targetId' => $targetDocument ? $targetDocument->getid() : null,
+            'targetPath' => $targetDocument?->getRealFullPath(),
+            'targetId' => $targetDocument?->getid(),
         ]);
     }
 
@@ -1299,7 +1300,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         $language = null;
         $translationLinks = null;
 
-        $document = Document::getByPath($request->get('path'));
+        $document = Document::getByPath($request->query->get('path'));
         if ($document) {
             $language = $document->getProperty('language');
             if ($language) {

--- a/src/Controller/Admin/Document/DocumentControllerBase.php
+++ b/src/Controller/Admin/Document/DocumentControllerBase.php
@@ -112,7 +112,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
     protected function addPropertiesToDocument(Request $request, Model\Document $document): void
     {
         // properties
-        if ($request->get('properties')) {
+        if ($request->request->has('properties')) {
             $properties = [];
             // assign inherited properties
             foreach ($document->getProperties() as $p) {
@@ -121,7 +121,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
                 }
             }
 
-            $propertiesData = $this->decodeJson($request->get('properties'));
+            $propertiesData = $this->decodeJson($request->request->get('properties'));
 
             if (is_array($propertiesData)) {
                 foreach ($propertiesData as $propertyName => $propertyData) {
@@ -157,8 +157,8 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
     protected function addSettingsToDocument(Request $request, Model\Document $document): void
     {
         // settings
-        if ($request->get('settings') && $document->isAllowed('settings')) {
-            $settings = $this->decodeJson($request->get('settings'));
+        if ($request->request->has('settings') && $document->isAllowed('settings')) {
+            $settings = $this->decodeJson($request->request->get('settings'));
             if (array_key_exists('prettyUrl', $settings)) {
                 $settings['prettyUrl'] = htmlspecialchars($settings['prettyUrl']);
             }
@@ -174,15 +174,15 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
                 && $document instanceof TargetingDocumentInterface
                 && $document->hasTargetGroupSpecificEditables();
 
-            if ($request->get('appendEditables') || $isTargetSpecificEditable) {
+            if ($request->request->get('appendEditables') || $isTargetSpecificEditable) {
                 $document->getEditables();
             } else {
                 // ensure no editables (e.g. from session, version, ...) are still referenced
                 $document->setEditables(null);
             }
 
-            if ($request->get('data')) {
-                $data = $this->decodeJson($request->get('data'));
+            if ($request->request->has('data')) {
+                $data = $this->decodeJson($request->request->get('data'));
                 foreach ($data as $name => $value) {
                     $data = $value['data'] ?? null;
                     $type = $value['type'];
@@ -206,7 +206,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
     #[Route('/save-to-session', name: 'savetosession', methods: ['POST'])]
     public function saveToSessionAction(Request $request): JsonResponse
     {
-        if ($documentId = (int) $request->get('id')) {
+        if ($documentId = (int) $request->request->get('id')) {
             if (!$document = Model\Document\Service::getElementFromSession('document', $documentId, $request->getSession()->getId())) {
                 $document = Model\Document\PageSnippet::getById($documentId);
                 if (!$document) {
@@ -257,7 +257,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
     #[Route('/remove-from-session', name: 'removefromsession', methods: ['DELETE'])]
     public function removeFromSessionAction(Request $request): JsonResponse
     {
-        Model\Document\Service::removeElementFromSession('document', $request->get('id'), $request->getSession()->getId());
+        Model\Document\Service::removeElementFromSession('document', $request->request->get('id'), $request->getSession()->getId());
 
         return $this->adminJson(['success' => true]);
     }
@@ -306,10 +306,10 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
     #[Route('/change-main-document', name: 'changemaindocument', methods: ['PUT'])]
     public function changeMainDocumentAction(Request $request): JsonResponse
     {
-        $doc = Model\Document\PageSnippet::getById((int) $request->get('id'));
+        $doc = Model\Document\PageSnippet::getById((int) $request->request->get('id'));
         if ($doc instanceof Model\Document\PageSnippet) {
             $doc->setEditables([]);
-            $doc->setContentMainDocumentId($request->get('contentMainDocumentPath'), true);
+            $doc->setContentMainDocumentId($request->request->get('contentMainDocumentPath'), true);
             $doc->saveVersion();
         }
 
@@ -365,7 +365,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
         $document->setModificationDate(time());
         $document->setUserModification($this->getAdminUser()->getId());
 
-        $task = strtolower($task ?? $request->get('task'));
+        $task = strtolower($task ?? $request->query->get('task'));
         $version = null;
         switch ($task) {
             case $task === self::TASK_PUBLISH && $document->isAllowed($task):

--- a/src/Controller/Admin/Document/EmailController.php
+++ b/src/Controller/Admin/Document/EmailController.php
@@ -35,7 +35,7 @@ class EmailController extends DocumentControllerBase
     #[Route('/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
-        $email = Document\Email::getById((int)$request->get('id'));
+        $email = Document\Email::getById((int)$request->query->get('id'));
 
         if (!$email) {
             throw $this->createNotFoundException('Email not found');
@@ -75,7 +75,7 @@ class EmailController extends DocumentControllerBase
     #[Route('/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $page = Document\Email::getById((int) $request->get('id'));
+        $page = Document\Email::getById((int) $request->query->get('id'));
         if (!$page) {
             throw $this->createNotFoundException('Email not found');
         }

--- a/src/Controller/Admin/Document/FolderController.php
+++ b/src/Controller/Admin/Document/FolderController.php
@@ -34,7 +34,7 @@ class FolderController extends DocumentControllerBase
     #[Route('/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
-        $folder = Document\Folder::getById((int)$request->get('id'));
+        $folder = Document\Folder::getById((int)$request->query->get('id'));
         if (!$folder) {
             throw $this->createNotFoundException('Folder not found');
         }
@@ -58,7 +58,7 @@ class FolderController extends DocumentControllerBase
     #[Route('/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $folder = Document\Folder::getById((int) $request->get('id'));
+        $folder = Document\Folder::getById((int) $request->request->get('id'));
         if (!$folder) {
             throw $this->createNotFoundException('Folder not found');
         }

--- a/src/Controller/Admin/Document/HardlinkController.php
+++ b/src/Controller/Admin/Document/HardlinkController.php
@@ -35,7 +35,7 @@ class HardlinkController extends DocumentControllerBase
     #[Route('/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
-        $link = Document\Hardlink::getById((int)$request->get('id'));
+        $link = Document\Hardlink::getById((int)$request->query->get('id'));
 
         if (!$link) {
             throw $this->createNotFoundException('Hardlink not found');
@@ -72,7 +72,7 @@ class HardlinkController extends DocumentControllerBase
     #[Route('/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $link = Document\Hardlink::getById((int) $request->get('id'));
+        $link = Document\Hardlink::getById((int) $request->request->get('id'));
         if (!$link) {
             throw $this->createNotFoundException('Hardlink not found');
         }
@@ -97,9 +97,8 @@ class HardlinkController extends DocumentControllerBase
      */
     protected function setValuesToDocument(Request $request, Document $document): void
     {
-        // data
-        if ($request->get('data')) {
-            $data = $this->decodeJson($request->get('data'));
+        if ($request->request->has('data')) {
+            $data = $this->decodeJson($request->request->get('data'));
 
             $sourceId = null;
             if ($sourceDocument = Document::getByPath($data['sourcePath'])) {

--- a/src/Controller/Admin/Document/LinkController.php
+++ b/src/Controller/Admin/Document/LinkController.php
@@ -39,7 +39,7 @@ class LinkController extends DocumentControllerBase
     #[Route('/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request, SerializerInterface $serializer): JsonResponse
     {
-        $link = Document\Link::getById((int)$request->get('id'));
+        $link = Document\Link::getById((int)$request->query->get('id'));
 
         if (!$link) {
             throw $this->createNotFoundException('Link not found');
@@ -76,7 +76,7 @@ class LinkController extends DocumentControllerBase
     #[Route('/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $link = Document\Link::getById((int) $request->get('id'));
+        $link = Document\Link::getById((int) $request->request->get('id'));
         if (!$link) {
             throw $this->createNotFoundException('Link not found');
         }
@@ -101,15 +101,14 @@ class LinkController extends DocumentControllerBase
      */
     protected function setValuesToDocument(Request $request, Document $document): void
     {
-        // data
-        if ($request->get('data')) {
-            $data = $this->decodeJson($request->get('data'));
+        if ($request->request->has('data')) {
+            $data = $this->decodeJson($request->request->get('data'));
 
             $path = $data['path'];
 
             if (!empty($path)) {
                 $target = null;
-                if ($data['linktype'] == 'internal' && $data['internalType']) {
+                if ($data['linktype'] === 'internal' && $data['internalType']) {
                     $target = Element\Service::getElementByPath($data['internalType'], $path);
                     if ($target) {
                         $data['internal'] = $target->getId();

--- a/src/Controller/Admin/Document/PageController.php
+++ b/src/Controller/Admin/Document/PageController.php
@@ -56,7 +56,7 @@ class PageController extends DocumentControllerBase
     #[Route('/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request, StaticPageGenerator $staticPageGenerator): JsonResponse
     {
-        $page = Document\Page::getById((int)$request->get('id'));
+        $page = Document\Page::getById((int)$request->query->get('id'));
 
         if (!$page) {
             throw $this->createNotFoundException('Page not found');
@@ -108,7 +108,7 @@ class PageController extends DocumentControllerBase
     #[Route('/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request, StaticPageGenerator $staticPageGenerator): JsonResponse
     {
-        $oldPage = Document\Page::getById((int) $request->get('id'));
+        $oldPage = Document\Page::getById((int) $request->request->get('id'));
         if (!$oldPage) {
             throw $this->createNotFoundException('Page not found');
         }
@@ -118,13 +118,12 @@ class PageController extends DocumentControllerBase
 
         $page = $pageSession ?: $this->getLatestVersion($oldPage);
 
-        if ($request->get('missingRequiredEditable') !== null) {
-            $page->setMissingRequiredEditable($request->get('missingRequiredEditable') == 'true');
+        if ($request->request->has('missingRequiredEditable')) {
+            $page->setMissingRequiredEditable($request->request->get('missingRequiredEditable') === 'true');
         }
 
-        $settings = [];
-        if ($request->get('settings')) {
-            $settings = $this->decodeJson($request->get('settings'));
+        if ($request->request->has('settings')) {
+            $settings = $this->decodeJson($request->request->get('settings'));
             if ($settings['published'] ?? false) {
                 $page->setMissingRequiredEditable(null);
             }
@@ -176,6 +175,7 @@ class PageController extends DocumentControllerBase
         $list = new Document\Listing();
         $list->setCondition('`type` = ?', ['page']);
 
+        // @todo: this seems completely wrong.
         foreach ($list->loadIdList() as $docId) {
             $messengerBusOpendxpCore->dispatch(
                 new GeneratePagePreviewMessage($docId, \OpenDxp\Tool::getHostUrl())
@@ -190,7 +190,7 @@ class PageController extends DocumentControllerBase
     #[Route('/display-preview-image', name: 'display_preview_image', methods: ['GET'])]
     public function displayPreviewImageAction(Request $request): BinaryFileResponse
     {
-        $document = Document\Page::getById((int) $request->get('id'));
+        $document = Document\Page::getById((int) $request->query->get('id'));
         if ($document instanceof Document\Page) {
             return new BinaryFileResponse($document->getPreviewImageFilesystemPath(), 200, [
                 'Content-Type' => 'image/jpg',
@@ -312,7 +312,7 @@ class PageController extends DocumentControllerBase
             ->size($request->query->get('download') ? 4000 : 500)
             ->build();
 
-        $tmpFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/qr-code-' . uniqid() . '.png';
+        $tmpFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/qr-code-' . uniqid('', false) . '.png';
         $result->saveToFile($tmpFile);
 
         $response = new BinaryFileResponse($tmpFile);
@@ -340,10 +340,10 @@ class PageController extends DocumentControllerBase
         DocumentResolver $documentResolver,
         LocaleServiceInterface $localeService
     ): JsonResponse {
-        $blockStateStackData = json_decode($request->get('blockStateStack'), true);
+        $blockStateStackData = json_decode($request->request->get('blockStateStack'), true);
         $blockStateStack->loadArray($blockStateStackData);
 
-        $document = Document\PageSnippet::getById((int) $request->get('documentId'));
+        $document = Document\PageSnippet::getById((int) $request->request->get('documentId'));
         if (!$document) {
             throw $this->createNotFoundException();
         }
@@ -362,14 +362,14 @@ class PageController extends DocumentControllerBase
         // setting locale manually here before rendering, to make sure editables use the right locale from document
         $localeService->setLocale($document->getProperty('language'));
 
-        $areaBlockConfig = json_decode($request->get('areablockConfig'), true);
+        $areaBlockConfig = json_decode($request->request->get('areablockConfig'), true);
         /** @var Document\Editable\Areablock $areablock */
-        $areablock = $editableRenderer->getEditable($document, 'areablock', $request->get('realName'), $areaBlockConfig, true);
-        $areablock->setRealName($request->get('realName'));
+        $areablock = $editableRenderer->getEditable($document, 'areablock', $request->request->get('realName'), $areaBlockConfig, true);
+        $areablock->setRealName($request->request->get('realName'));
         $areablock->setEditmode(true);
-        $areaBrickData = json_decode($request->get('areablockData'), true);
+        $areaBrickData = json_decode($request->request->get('areablockData'), true);
         $areablock->setDataFromEditmode($areaBrickData);
-        $htmlCode = trim($areablock->renderIndex((int) $request->get('index'), true));
+        $htmlCode = trim($areablock->renderIndex((int) $request->request->get('index'), true));
 
         return new JsonResponse([
             'editableDefinitions' => $definitionCollector->getDefinitions(),

--- a/src/Controller/Admin/Document/RenderletController.php
+++ b/src/Controller/Admin/Document/RenderletController.php
@@ -40,7 +40,7 @@ class RenderletController extends AdminAbstractController
     /**
      * Handles editmode preview for renderlets
      */
-    #[Route('/document_tag/renderlet', name: 'opendxp_admin_document_renderlet_renderlet')]
+    #[Route('/document_tag/renderlet', name: 'opendxp_admin_document_renderlet_renderlet', methods: ['GET'])]
     public function renderletAction(
         Request $request,
         ActionRenderer $actionRenderer,
@@ -48,6 +48,7 @@ class RenderletController extends AdminAbstractController
         LocaleServiceInterface $localeService,
         EventDispatcherInterface $eventDispatcher
     ): Response {
+
         $query = $request->query->all();
         $attributes = [];
 
@@ -55,15 +56,16 @@ class RenderletController extends AdminAbstractController
         $element = $this->loadElement($request);
 
         $event = new GenericEvent($this, [
-            'requestParams' => [...$request->request->all(), ...$request->query->all()],
+            'requestParams' => $query,
             'element' => $element,
         ]);
+
         $eventDispatcher->dispatch($event, DocumentEvents::EDITABLE_RENDERLET_PRE_RENDER);
 
-        $controller = $request->get('controller');
+        $controller = $request->query->get('controller');
 
         // set document if set in request
-        if ($documentId = $request->get('opendxp_parentDocument')) {
+        if ($documentId = $request->query->get('opendxp_parentDocument')) {
             $document = Document\PageSnippet::getById((int) $documentId);
             if ($document) {
                 $attributes = $actionRenderer->addDocumentAttributes($document, $attributes);
@@ -72,7 +74,7 @@ class RenderletController extends AdminAbstractController
         }
 
         // override template if set
-        if ($template = $request->get('template')) {
+        if ($template = $request->query->get('template')) {
             $attributes[DynamicRouter::CONTENT_TEMPLATE] = $template;
         }
 
@@ -97,8 +99,8 @@ class RenderletController extends AdminAbstractController
     {
         $element = null;
 
-        $id = $request->get('id');
-        $type = $request->get('type');
+        $id = $request->query->get('id');
+        $type = $request->query->get('type');
 
         if ($id && $type) {
             $element = Service::getElementById($type, (int)$id);

--- a/src/Controller/Admin/Document/SnippetController.php
+++ b/src/Controller/Admin/Document/SnippetController.php
@@ -36,7 +36,7 @@ class SnippetController extends DocumentControllerBase
     #[Route('/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
-        $snippet = Document\Snippet::getById((int)$request->get('id'));
+        $snippet = Document\Snippet::getById((int)$request->query->get('id'));
 
         if (!$snippet) {
             throw $this->createNotFoundException('Snippet not found');
@@ -83,7 +83,7 @@ class SnippetController extends DocumentControllerBase
     #[Route('/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $snippet = Document\Snippet::getById((int) $request->get('id'));
+        $snippet = Document\Snippet::getById((int) $request->request->get('id'));
         if (!$snippet) {
             throw $this->createNotFoundException('Snippet not found');
         }
@@ -93,8 +93,8 @@ class SnippetController extends DocumentControllerBase
 
         $snippet = $snippetSession ?: $this->getLatestVersion($snippet);
 
-        if ($request->get('missingRequiredEditable') !== null) {
-            $snippet->setMissingRequiredEditable($request->get('missingRequiredEditable') == 'true');
+        if ($request->request->has('missingRequiredEditable')) {
+            $snippet->setMissingRequiredEditable($request->request->get('missingRequiredEditable') === 'true');
         }
 
         [$task, $snippet, $version] = $this->saveDocument($snippet, $request);

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -52,7 +52,7 @@ class ElementController extends AdminAbstractController
     #[Route('/element/unlock-element', name: 'opendxp_admin_element_unlockelement', methods: ['PUT'])]
     public function unlockElementAction(Request $request): Response
     {
-        Element\Editlock::unlock((int)$request->get('id'), $request->get('type'));
+        Element\Editlock::unlock((int)$request->request->get('id'), $request->request->get('type'));
 
         return $this->adminJson(['success' => true]);
     }
@@ -129,7 +129,7 @@ class ElementController extends AdminAbstractController
     #[Route('/element/note-types', name: 'opendxp_admin_element_notetypes', methods: ['GET'])]
     public function noteTypes(Request $request): JsonResponse
     {
-        return match ($request->get('ctype')) {
+        return match ($request->query->get('ctype')) {
             'document' => $this->processNoteTypesFromParameters(OpenDxpAdminExtension::PARAM_DOCUMENTS_NOTES_EVENTS_TYPES),
             'asset' => $this->processNoteTypesFromParameters(OpenDxpAdminExtension::PARAM_ASSETS_NOTES_EVENTS_TYPES),
             'object' => $this->processNoteTypesFromParameters(OpenDxpAdminExtension::PARAM_DATAOBJECTS_NOTES_EVENTS_TYPES),
@@ -155,14 +155,14 @@ class ElementController extends AdminAbstractController
 
         $list = new Element\Note\Listing();
 
-        $offset = (int) $request->get('start', 0);
-        $limit = $request->get('limit');
+        $offset = (int) $request->request->get('start', 0);
+        $limit = $request->request->get('limit');
         $limit = $limit ? (int) $limit : null;
 
         $list->setLimit($limit);
         $list->setOffset($offset);
 
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings([...$request->request->all(), ...$request->query->all()]);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->request->all());
         if ($sortingSettings['orderKey'] && $sortingSettings['order']) {
             $list->setOrderKey($sortingSettings['orderKey']);
             $list->setOrder($sortingSettings['order']);
@@ -172,7 +172,7 @@ class ElementController extends AdminAbstractController
         }
 
         $conditions = [];
-        $filterText = $request->get('filterText');
+        $filterText = $request->request->get('filterText');
 
         if ($filterText) {
             $conditions[] = '('
@@ -184,7 +184,7 @@ class ElementController extends AdminAbstractController
                 . ')';
         }
 
-        $filterJson = $request->get('filter');
+        $filterJson = $request->request->get('filter');
         if ($filterJson) {
             $db = Db::get();
             $filters = $this->decodeJson($filterJson);
@@ -194,28 +194,28 @@ class ElementController extends AdminAbstractController
             foreach ($filters as $filter) {
                 $operator = '=';
 
-                if ($filter['type'] == 'string') {
+                if ($filter['type'] === 'string') {
                     $operator = 'LIKE';
-                } elseif ($filter['type'] == 'numeric') {
-                    if ($filter[$comparisonKey] == 'lt') {
+                } elseif ($filter['type'] === 'numeric') {
+                    if ($filter[$comparisonKey] === 'lt') {
                         $operator = '<';
-                    } elseif ($filter[$comparisonKey] == 'gt') {
+                    } elseif ($filter[$comparisonKey] === 'gt') {
                         $operator = '>';
-                    } elseif ($filter[$comparisonKey] == 'eq') {
+                    } elseif ($filter[$comparisonKey] === 'eq') {
                         $operator = '=';
                     }
-                } elseif ($filter['type'] == 'date') {
-                    if ($filter[$comparisonKey] == 'lt') {
+                } elseif ($filter['type'] === 'date') {
+                    if ($filter[$comparisonKey] === 'lt') {
                         $operator = '<';
-                    } elseif ($filter[$comparisonKey] == 'gt') {
+                    } elseif ($filter[$comparisonKey] === 'gt') {
                         $operator = '>';
-                    } elseif ($filter[$comparisonKey] == 'eq') {
+                    } elseif ($filter[$comparisonKey] === 'eq') {
                         $operator = '=';
                     }
                     $filter['value'] = strtotime($filter['value']);
-                } elseif ($filter[$comparisonKey] == 'list') {
+                } elseif ($filter[$comparisonKey] === 'list') {
                     $operator = '=';
-                } elseif ($filter[$comparisonKey] == 'boolean') {
+                } elseif ($filter[$comparisonKey] === 'boolean') {
                     $operator = '=';
                     $filter['value'] = (int) $filter['value'];
                 }
@@ -225,9 +225,9 @@ class ElementController extends AdminAbstractController
                     $value = '%' . $value . '%';
                 }
 
-                if ($filter[$propertyKey] == 'user') {
+                if ($filter[$propertyKey] === 'user') {
                     $conditions[] = '`user` IN (SELECT `id` FROM `users` WHERE `name` LIKE ' . $list->quote($value) . ')';
-                } elseif ($filter['type'] == 'date' && $filter[$comparisonKey] == 'eq') {
+                } elseif ($filter['type'] === 'date' && $filter[$comparisonKey] === 'eq') {
                     $maxTime = $value + (86400 - 1);
                     //specifies the top point of the range used in the condition
                     $dateCondition = '`' . $filter[$propertyKey] . '` ' . ' BETWEEN ' . $db->quote($value) . ' AND ' . $db->quote($maxTime);
@@ -238,8 +238,8 @@ class ElementController extends AdminAbstractController
             }
         }
 
-        if ($request->get('cid') && $request->get('ctype')) {
-            $conditions[] = '(cid = ' . $list->quote($request->get('cid')) . ' AND ctype = ' . $list->quote($request->get('ctype')) . ')';
+        if ($request->request->has('cid') && $request->request->has('ctype')) {
+            $conditions[] = '(cid = ' . $list->quote($request->request->get('cid')) . ' AND ctype = ' . $list->quote($request->request->get('ctype')) . ')';
         }
 
         if ($conditions !== []) {
@@ -269,12 +269,12 @@ class ElementController extends AdminAbstractController
         $this->checkPermission('notes_events');
 
         $note = new Element\Note();
-        $note->setCid((int) $request->get('cid'));
-        $note->setCtype($request->get('ctype'));
+        $note->setCid((int) $request->request->get('cid'));
+        $note->setCtype($request->request->get('ctype'));
         $note->setDate(time());
-        $note->setTitle($request->get('title'));
-        $note->setDescription($request->get('description'));
-        $note->setType($request->get('type'));
+        $note->setTitle($request->request->get('title'));
+        $note->setDescription($request->request->get('description'));
+        $note->setType($request->request->get('type'));
         $note->setLocked(false);
         $note->save();
 
@@ -297,14 +297,14 @@ class ElementController extends AdminAbstractController
         $success = false;
         $hasHidden = false;
         $total = 0;
-        $limit = (int)$request->get('limit', 50);
-        $offset = (int)$request->get('start', 0);
+        $limit = (int)$request->query->get('limit', 50);
+        $offset = (int)$request->query->get('start', 0);
 
         if ($element instanceof Element\ElementInterface) {
             $total = $element->getDependencies()->getRequiredByTotalCount();
 
-            if ($request->get('sort')) {
-                $sort = json_decode($request->get('sort'))[0];
+            if ($request->query->has('sort')) {
+                $sort = json_decode($request->query->get('sort'))[0];
                 $orderBy = $sort->property;
                 $orderDirection = $sort->direction;
             } else {
@@ -377,12 +377,12 @@ class ElementController extends AdminAbstractController
         $targetEl = Element\Service::getElementById($request->request->get('targetType'), $request->request->getInt('targetId'));
 
         if ($element && $sourceEl && $targetEl
-            && $request->get('sourceType') == $request->get('targetType')
+            && $request->request->get('sourceType') === $request->request->get('targetType')
             && $sourceEl->getType() === $targetEl->getType()
             && $element->isAllowed('save')
         ) {
             $rewriteConfig = [
-                $request->get('sourceType') => [
+                $request->request->get('sourceType') => [
                     $sourceEl->getId() => $targetEl->getId(),
                 ],
             ];
@@ -465,7 +465,7 @@ class ElementController extends AdminAbstractController
     #[Route('/element/version-update', name: 'opendxp_admin_element_versionupdate', methods: ['PUT'])]
     public function versionUpdateAction(Request $request): JsonResponse
     {
-        $data = $this->decodeJson($request->get('data'));
+        $data = $this->decodeJson($request->request->get('data'));
 
         $version = Version::getById($data['id']);
 
@@ -484,35 +484,40 @@ class ElementController extends AdminAbstractController
     #[Route('/element/get-nice-path', name: 'opendxp_admin_element_getnicepath', methods: ['POST'])]
     public function getNicePathAction(Request $request): JsonResponse
     {
-        $source = $this->decodeJson($request->get('source'));
-        if ($source['type'] != 'object') {
+        $source = $this->decodeJson($request->request->get('source'));
+
+        if ($source['type'] !== 'object') {
             throw new Exception('currently only objects as source elements are supported');
         }
+
         $result = [];
         $id = $source['id'];
         $source = DataObject\Concrete::getById($id);
-        $context = $request->get('context') ? $this->decodeJson($request->get('context')) : [];
+        $context = $request->request->has('context') ? $this->decodeJson($request->request->get('context')) : [];
 
         $ownerType = $context['containerType'];
         $fieldname = $context['fieldname'];
 
         $fd = $this->getNicePathFormatterFieldDefinition($source, $context);
 
-        $targets = $this->decodeJson($request->get('targets'));
+        $targets = $this->decodeJson($request->request->get('targets'));
 
         $result = $this->convertResultWithPathFormatter($source, $context, $result, $targets);
 
         if ($request->request->getBoolean('loadEditModeData')) {
-            $idProperty = $request->get('idProperty', 'id');
+            $idProperty = $request->request->get('idProperty', 'id');
             $methodName = 'get' . ucfirst($fieldname);
-            if ($ownerType == 'object' && method_exists($source, $methodName)) {
+            if ($ownerType === 'object' && method_exists($source, $methodName)) {
                 $data = DataObject\Service::useInheritedValues(true, [$source, $methodName]);
                 $editModeData = $fd->getDataForEditmode($data, $source);
                 // Inherited values show as an empty array
                 if (is_array($editModeData) && $editModeData !== []) {
                     foreach ($editModeData as $relationObjectAttribute) {
-                        $relationObjectAttribute['$$nicepath'] =
-                            isset($relationObjectAttribute[$idProperty]) && isset($result[$relationObjectAttribute[$idProperty]]) ? $result[$relationObjectAttribute[$idProperty]] : null;
+
+                        $relationObjectAttribute['$$nicepath'] = isset($relationObjectAttribute[$idProperty], $result[$relationObjectAttribute[$idProperty]])
+                            ? $result[$relationObjectAttribute[$idProperty]]
+                            : null;
+
                         $result[$relationObjectAttribute[$idProperty]] = $relationObjectAttribute;
                     }
                 } else {
@@ -534,8 +539,8 @@ class ElementController extends AdminAbstractController
     #[Route('/element/get-versions', name: 'opendxp_admin_element_getversions', methods: ['GET'])]
     public function getVersionsAction(Request $request): JsonResponse
     {
-        $id = (int)$request->get('id');
-        $type = $request->get('elementType');
+        $id = (int)$request->query->get('id');
+        $type = $request->query->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
 
         if ($id && in_array($type, $allowedTypes)) {
@@ -587,7 +592,8 @@ class ElementController extends AdminAbstractController
     #[Route('/element/delete-draft', name: 'opendxp_admin_element_deletedraft', methods: ['DELETE'])]
     public function deleteDraftAction(Request $request): JsonResponse
     {
-        $version = Version::getById((int) $request->get('id'));
+        $version = Version::getById((int) $request->request->get('id'));
+
         if ($version) {
             $version->delete();
         }
@@ -598,7 +604,7 @@ class ElementController extends AdminAbstractController
     #[Route('/element/delete-version', name: 'opendxp_admin_element_deleteversion', methods: ['DELETE'])]
     public function deleteVersionAction(Request $request): JsonResponse
     {
-        $version = Model\Version::getById((int) $request->get('id'));
+        $version = Model\Version::getById((int) $request->request->get('id'));
         $version->delete();
 
         return $this->adminJson(['success' => true]);
@@ -629,9 +635,9 @@ class ElementController extends AdminAbstractController
         $id = $request->query->getInt('id');
         $type = $request->query->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
-        $offset = (int) $request->get('start', 0);
-        $limit = (int) $request->get('limit', 25);
-        $filterRequires = $request->get('filter');
+        $offset = (int) $request->query->get('start', 0);
+        $limit = (int) $request->query->get('limit', 25);
+        $filterRequires = $request->query->get('filter');
         $value = null;
         $elements = null;
 
@@ -644,19 +650,13 @@ class ElementController extends AdminAbstractController
 
                 foreach ($filters as $filter) {
 
-                    if ($filter['type'] == 'string') {
+                    if ($filter['type'] === 'string') {
                         $value = ($filter['value']??'');
                     }
 
                     $elements = $element->getDependencies()->getFilterRequiresByPath($offset, $limit, $value);
 
                 }
-
-                $result = [
-                    'start' => $offset,
-                    'limit' => $limit,
-                    'requires' => [],  // Initialize 'requires' as an empty array
-                ];
 
                 if (count($elements) > 0) {
                     $result = Model\Element\Service::getFilterRequiresForFrontend($elements);
@@ -689,9 +689,9 @@ class ElementController extends AdminAbstractController
         $id = $request->query->getInt('id');
         $type = $request->query->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
-        $offset = (int) $request->get('start', 0);
-        $limit = (int) $request->get('limit', 25);
-        $filterRequiredBy = $request->get('filter');
+        $offset = (int) $request->query->get('start', 0);
+        $limit = (int) $request->query->get('limit', 25);
+        $filterRequiredBy = $request->query->get('filter');
         $value = null;
         $elements = null;
 
@@ -747,8 +747,8 @@ class ElementController extends AdminAbstractController
     public function getPredefinedPropertiesAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
         $properties = [];
-        $type = $request->get('elementType');
-        $query = $request->get('query');
+        $type = $request->query->get('elementType');
+        $query = $request->query->get('query');
         $allowedTypes = ['asset', 'document', 'object'];
 
         if (in_array($type, $allowedTypes, true)) {

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -297,8 +297,8 @@ class ElementController extends AdminAbstractController
         $success = false;
         $hasHidden = false;
         $total = 0;
-        $limit = (int)$request->query->get('limit', 50);
-        $offset = (int)$request->query->get('start', 0);
+        $limit = (int)$request->query->get('limit', '50');
+        $offset = (int)$request->query->get('start', '0');
 
         if ($element instanceof Element\ElementInterface) {
             $total = $element->getDependencies()->getRequiredByTotalCount();
@@ -635,8 +635,8 @@ class ElementController extends AdminAbstractController
         $id = $request->query->getInt('id');
         $type = $request->query->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
-        $offset = (int) $request->query->get('start', 0);
-        $limit = (int) $request->query->get('limit', 25);
+        $offset = (int) $request->query->get('start', '0');
+        $limit = (int) $request->query->get('limit', '25');
         $filterRequires = $request->query->get('filter');
         $value = null;
         $elements = null;
@@ -689,8 +689,8 @@ class ElementController extends AdminAbstractController
         $id = $request->query->getInt('id');
         $type = $request->query->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
-        $offset = (int) $request->query->get('start', 0);
-        $limit = (int) $request->query->get('limit', 25);
+        $offset = (int) $request->query->get('start', '0');
+        $limit = (int) $request->query->get('limit', '25');
         $filterRequiredBy = $request->query->get('filter');
         $value = null;
         $elements = null;
@@ -704,7 +704,7 @@ class ElementController extends AdminAbstractController
 
                 foreach ($filters as $filter) {
 
-                    if ($filter['type'] == 'string') {
+                    if ($filter['type'] === 'string') {
                         $value = ($filter['value']??'');
                     }
 

--- a/src/Controller/Admin/ElementControllerBase.php
+++ b/src/Controller/Admin/ElementControllerBase.php
@@ -57,12 +57,12 @@ abstract class ElementControllerBase extends AdminAbstractController
     #[Route('/tree-get-root', name: 'treegetroot', methods: ['GET'])]
     public function treeGetRootAction(Request $request): JsonResponse
     {
-        $type = $request->get('elementType');
+        $type = $request->query->get('elementType');
         $allowedTypes = ['asset', 'document', 'object'];
 
         $id = 1;
-        if ($request->get('id')) {
-            $id = (int)$request->get('id');
+        if ($request->query->get('id')) {
+            $id = (int)$request->query->get('id');
         }
 
         if (in_array($type, $allowedTypes)) {
@@ -90,9 +90,9 @@ abstract class ElementControllerBase extends AdminAbstractController
 
         $totalChildren = 0;
 
-        $ids = $request->get('id');
+        $ids = $request->query->get('id');
         $ids = explode(',', $ids);
-        $type = $request->get('type');
+        $type = $request->query->get('type');
 
         foreach ($ids as $id) {
             try {

--- a/src/Controller/Admin/EmailController.php
+++ b/src/Controller/Admin/EmailController.php
@@ -48,15 +48,15 @@ class EmailController extends AdminAbstractController
         }
 
         $list = new Tool\Email\Log\Listing();
-        if ($request->get('documentId')) {
-            $list->setCondition('documentId = ' . (int)$request->get('documentId'));
+        if ($request->request->has('documentId')) {
+            $list->setCondition('documentId = ' . (int)$request->request->get('documentId'));
         }
-        $list->setLimit((int)$request->get('limit', 50));
-        $list->setOffset((int)$request->get('start', 0));
+        $list->setLimit((int)$request->request->get('limit', 50));
+        $list->setOffset((int)$request->request->get('start', 0));
         $list->setOrderKey('sentDate');
 
-        if ($request->get('filter')) {
-            $filterTerm = $request->get('filter');
+        if ($request->request->has('filter')) {
+            $filterTerm = $request->request->get('filter');
             if ($filterTerm === '*') {
                 $filterTerm = '';
             }
@@ -82,8 +82,8 @@ class EmailController extends AdminAbstractController
 
             $condition = '( MATCH (`from`,`to`,`cc`,`bcc`,`subject`,`params`) AGAINST (' . $list->quote($filterTerm) . ' IN BOOLEAN MODE) )';
 
-            if ($request->get('documentId')) {
-                $condition .= 'AND documentId = ' . (int)$request->get('documentId');
+            if ($request->request->has('documentId')) {
+                $condition .= 'AND documentId = ' . (int)$request->request->get('documentId');
             }
 
             $list->setCondition($condition);
@@ -121,8 +121,8 @@ class EmailController extends AdminAbstractController
             throw $this->createAccessDeniedHttpException("Permission denied, user needs 'emails' permission.");
         }
 
-        $type = $request->get('type');
-        $emailLog = Tool\Email\Log::getById((int) $request->get('id'));
+        $type = $request->query->get('type');
+        $emailLog = Tool\Email\Log::getById((int) $request->query->get('id'));
 
         if (!$emailLog) {
             throw $this->createNotFoundException();
@@ -247,7 +247,7 @@ class EmailController extends AdminAbstractController
         }
 
         $success = false;
-        $emailLog = Tool\Email\Log::getById((int) $request->get('id'));
+        $emailLog = Tool\Email\Log::getById((int) $request->request->get('id'));
         if ($emailLog instanceof Tool\Email\Log) {
             $emailLog->delete();
             $success = true;
@@ -269,14 +269,14 @@ class EmailController extends AdminAbstractController
         }
 
         $success = false;
-        $emailLog = Tool\Email\Log::getById((int) $request->get('id'));
+        $emailLog = Tool\Email\Log::getById((int) $request->request->get('id'));
 
         if ($emailLog instanceof Tool\Email\Log) {
             $mail = new Mail();
             $mail->preventDebugInformationAppending();
             $mail->setIgnoreDebugMode(true);
 
-            if (!empty($request->get('to'))) {
+            if (!empty($request->request->get('to'))) {
                 $emailLog->setTo(null);
                 $emailLog->setCc(null);
                 $emailLog->setBcc(null);
@@ -293,7 +293,7 @@ class EmailController extends AdminAbstractController
             }
 
             foreach (['From', 'To', 'Cc', 'Bcc', 'ReplyTo'] as $field) {
-                if (!$values = $request->get(strtolower($field))) {
+                if (!$values = $request->request->get(strtolower($field))) {
                     $getter = 'get' . $field;
                     $values = $emailLog->{$getter}();
                 }
@@ -363,17 +363,17 @@ class EmailController extends AdminAbstractController
 
         $mail = new Mail();
 
-        if ($request->get('emailType') === 'text') {
-            $mail->text(strip_tags($request->get('content')));
-        } elseif ($request->get('emailType') === 'html') {
-            $mail->html($request->get('content'));
-        } elseif ($request->get('emailType') === 'document') {
-            $doc = \OpenDxp\Model\Document::getByPath($request->get('documentPath'));
+        if ($request->request->get('emailType') === 'text') {
+            $mail->text(strip_tags($request->request->get('content')));
+        } elseif ($request->request->get('emailType') === 'html') {
+            $mail->html($request->request->get('content'));
+        } elseif ($request->request->get('emailType') === 'document') {
+            $doc = \OpenDxp\Model\Document::getByPath($request->request->get('documentPath'));
 
             if ($doc instanceof \OpenDxp\Model\Document\Email) {
                 $mail->setDocument($doc);
 
-                if ($request->get('mailParamaters') && $mailParamsArray = json_decode($request->get('mailParamaters'), true)) {
+                if ($request->request->has('mailParamaters') && $mailParamsArray = json_decode($request->request->get('mailParamaters'), true)) {
                     foreach ($mailParamsArray as $mailParam) {
                         if ($mailParam['key']) {
                             $mail->setParam($mailParam['key'], $mailParam['value']);
@@ -385,7 +385,7 @@ class EmailController extends AdminAbstractController
             }
         }
 
-        if ($from = $request->get('from')) {
+        if ($from = $request->request->get('from')) {
             $addressArray = \OpenDxp\Helper\Mail::parseEmailAddressField($from);
             if ($addressArray) {
                 //use the first address only
@@ -394,12 +394,12 @@ class EmailController extends AdminAbstractController
             }
         }
 
-        $toAddresses = \OpenDxp\Helper\Mail::parseEmailAddressField($request->get('to'));
+        $toAddresses = \OpenDxp\Helper\Mail::parseEmailAddressField($request->request->get('to'));
         foreach ($toAddresses as $cleanedToAddress) {
             $mail->addTo($cleanedToAddress['email'], $cleanedToAddress['name']);
         }
 
-        $mail->subject($request->get('subject'));
+        $mail->subject($request->request->get('subject'));
         $mail->setIgnoreDebugMode(true);
 
         $mail->send();
@@ -419,8 +419,8 @@ class EmailController extends AdminAbstractController
             throw new Exception("Permission denied, user needs 'emails' permission.");
         }
 
-        if ($request->get('data')) {
-            $data = $this->decodeJson($request->get('data'));
+        if ($request->request->has('data')) {
+            $data = $this->decodeJson($request->request->get('data'));
 
             if (is_array($data)) {
                 foreach ($data as $key => &$value) {
@@ -434,14 +434,14 @@ class EmailController extends AdminAbstractController
                 }
             }
 
-            if ($request->get('xaction') === 'destroy') {
+            if ($request->query->get('xaction') === 'destroy') {
                 $address = Tool\Email\Blocklist::getByAddress($data['address']);
                 $address->delete();
 
                 return $this->adminJson(['success' => true, 'data' => []]);
             }
 
-            if ($request->get('xaction') === 'update') {
+            if ($request->query->get('xaction') === 'update') {
                 $address = Tool\Email\Blocklist::getByAddress($data['address']);
                 $address->setValues($data);
                 $address->save();
@@ -449,7 +449,7 @@ class EmailController extends AdminAbstractController
                 return $this->adminJson(['data' => $address->getObjectVars(), 'success' => true]);
             }
 
-            if ($request->get('xaction') === 'create') {
+            if ($request->query->get('xaction') === 'create') {
                 unset($data['id']);
 
                 $address = new Tool\Email\Blocklist();
@@ -459,23 +459,21 @@ class EmailController extends AdminAbstractController
                 return $this->adminJson(['data' => $address->getObjectVars(), 'success' => true]);
             }
         } else {
-            // get list of routes
 
             $list = new Tool\Email\Blocklist\Listing();
 
-            $list->setLimit((int) $request->get('limit', 50));
-            $list->setOffset((int) $request->get('start', 0));
+            $list->setLimit((int) $request->request->get('limit', 50));
+            $list->setOffset((int) $request->request->get('start', 0));
 
-            $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->query->all());
+            $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->request->all());
+
             if ($sortingSettings['orderKey']) {
-                $orderKey = $sortingSettings['orderKey'];
-            }
-            if ($sortingSettings['order']) {
-                $order = $sortingSettings['order'];
+                $list->setOrderKey($sortingSettings['orderKey']);
+                $list->setOrder($sortingSettings['order']);
             }
 
-            if ($request->get('filter')) {
-                $list->setCondition('`address` LIKE ' . $list->quote('%'.$request->get('filter').'%'));
+            if ($request->request->has('filter')) {
+                $list->setCondition('`address` LIKE ' . $list->quote('%'.$request->request->get('filter').'%'));
             }
 
             $data = $list->load();

--- a/src/Controller/Admin/LoginController.php
+++ b/src/Controller/Admin/LoginController.php
@@ -105,8 +105,10 @@ class LoginController extends AdminAbstractController implements KernelControlle
         CsrfProtectionHandler $csrfProtection,
         Config $config
     ): RedirectResponse|Response {
+
         $queryParams = $request->query->all();
-        if ($request->get('_route') === 'opendxp_admin_login_fallback') {
+
+        if ($request->attributes->get('_route') === 'opendxp_admin_login_fallback') {
             return $this->redirectToRoute('opendxp_admin_login', $queryParams, Response::HTTP_MOVED_PERMANENTLY);
         }
 
@@ -134,16 +136,16 @@ class LoginController extends AdminAbstractController implements KernelControlle
 
         $params['csrfTokenRefreshInterval'] = ((int)$session_gc_maxlifetime - 60) * 1000;
 
-        if ($request->get('too_many_attempts')) {
-            $params['error'] = SecurityHelper::convertHtmlSpecialChars($request->get('too_many_attempts'));
+        if ($request->query->has('too_many_attempts')) {
+            $params['error'] = SecurityHelper::convertHtmlSpecialChars($request->query->get('too_many_attempts'));
         }
-        if ($request->get('auth_failed')) {
+        if ($request->query->has('auth_failed')) {
             $params['error'] = 'error_auth_failed';
         }
-        if ($request->get('session_expired')) {
+        if ($request->query->has('session_expired')) {
             $params['error'] = 'error_session_expired';
         }
-        if ($request->get('deeplink')) {
+        if ($request->query->has('deeplink')) {
             $params['deeplink'] = true;
         }
 
@@ -189,8 +191,13 @@ class LoginController extends AdminAbstractController implements KernelControlle
     #[Route('/login/login', name: 'opendxp_admin_login_check')]
     public function loginCheckAction(Request $request): RedirectResponse
     {
+        $params = [];
+        if ($request->query->has('perspective')) {
+            $params['perspective'] = strip_tags($request->query->get('perspective'));
+        }
+
         // just in case the authenticator didn't redirect
-        return new RedirectResponse($this->generateUrl('opendxp_admin_login', ['perspective' => strip_tags($request->get('perspective', ''))]));
+        return new RedirectResponse($this->generateUrl('opendxp_admin_login', $params));
     }
 
     #[Route('/login/lostpassword', name: 'opendxp_admin_login_lostpassword')]
@@ -204,7 +211,9 @@ class LoginController extends AdminAbstractController implements KernelControlle
         $params = $this->buildLoginPageViewParams($config);
         $error = null;
 
-        if ($request->getMethod() === 'POST' && $username = $request->get('username')) {
+        if ($request->getMethod() === 'POST' && $request->request->has('username')) {
+
+            $username = $request->request->get('username');
             $user = User::getByName($username);
             if (!$user instanceof User) {
                 $error = 'user_unknown';
@@ -282,16 +291,17 @@ class LoginController extends AdminAbstractController implements KernelControlle
     public function deeplinkAction(Request $request): Response
     {
         // check for deeplink
-        $queryString = $_SERVER['QUERY_STRING'];
+        $queryString = $request->server->get('QUERY_STRING');
 
         if (preg_match('/(document|asset|object)_(\d+)_([a-z]+)/', $queryString, $deeplink)) {
             $deeplink = $deeplink[0];
-            $perspective = strip_tags($request->get('perspective', ''));
+            $perspective = strip_tags($request->query->get('perspective', ''));
             if (strpos($queryString, 'token')) {
                 $url = $this->dispatchLoginRedirect([
                     'deeplink' => $deeplink,
                     'perspective' => $perspective,
                 ]);
+
                 $url .= '&' . $queryString;
 
                 return $this->redirect($url);

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -77,7 +77,7 @@ class MiscController extends AdminAbstractController
     #[Route('/json-translations-system', name: 'opendxp_admin_misc_jsontranslationssystem', methods: ['GET'])]
     public function jsonTranslationsSystemAction(Request $request, TranslatorInterface $translator): Response
     {
-        $language = $request->get('language');
+        $language = $request->query->get('language');
 
         /** @var Translator $translator */
         $translator->lazyInitialize('admin', $language);
@@ -119,7 +119,7 @@ class MiscController extends AdminAbstractController
     #[Route('/script-proxy', name: 'opendxp_admin_misc_scriptproxy', methods: ['GET'])]
     public function scriptProxyAction(Request $request): Response
     {
-        $storageFile = $request->get('storageFile');
+        $storageFile = $request->query->get('storageFile');
         if (!$storageFile) {
             throw new InvalidArgumentException('The parameter storageFile is required');
         }
@@ -193,7 +193,7 @@ class MiscController extends AdminAbstractController
     public function getValidFilenameAction(Request $request): JsonResponse
     {
         return $this->adminJson([
-            'filename' => \OpenDxp\Model\Element\Service::getValidKey($request->get('value'), $request->get('type')),
+            'filename' => \OpenDxp\Model\Element\Service::getValidKey($request->query->get('value'), $request->query->get('type')),
         ]);
     }
 
@@ -202,11 +202,11 @@ class MiscController extends AdminAbstractController
     {
         $this->checkPermission('maintenance_mode');
 
-        if ($request->get('activate')) {
+        if ($request->query->get('activate')) {
             $maintenanceModeHelper->activate($request->getSession()->getId());
         }
 
-        if ($request->get('deactivate')) {
+        if ($request->query->get('deactivate')) {
             $maintenanceModeHelper->deactivate();
         }
 
@@ -253,7 +253,8 @@ class MiscController extends AdminAbstractController
     #[Route('/get-language-flag', name: 'opendxp_admin_misc_getlanguageflag', methods: ['GET'])]
     public function getLanguageFlagAction(Request $request): BinaryFileResponse
     {
-        $iconPath = AdminTool::getLanguageFlagFile($request->get('language'));
+        $iconPath = AdminTool::getLanguageFlagFile($request->query->get('language'));
+
         $response = new BinaryFileResponse($iconPath);
         $response->headers->set('Content-Type', 'image/svg+xml');
 
@@ -267,7 +268,7 @@ class MiscController extends AdminAbstractController
             $profiler->disable();
         }
 
-        $type = $request->get('type');
+        $type = $request->query->get('type');
         $publicDir = OPENDXP_WEB_ROOT . '/bundles/opendxpadmin';
         $iconDir = $publicDir . '/img';
         $extraInfo = null;

--- a/src/Controller/Admin/PortalController.php
+++ b/src/Controller/Admin/PortalController.php
@@ -36,16 +36,6 @@ class PortalController extends AdminAbstractController implements KernelControll
 {
     protected ?Dashboard $dashboardHelper = null;
 
-    protected function getCurrentConfiguration(Request $request): array
-    {
-        return $this->dashboardHelper->getDashboard($request->get('key'));
-    }
-
-    protected function saveConfiguration(Request $request, array $config): void
-    {
-        $this->dashboardHelper->saveDashboard($request->get('key'), $config);
-    }
-
     #[Route('/dashboard-list', name: 'opendxp_admin_portal_dashboardlist', methods: ['GET'])]
     public function dashboardListAction(Request $request): JsonResponse
     {
@@ -53,7 +43,7 @@ class PortalController extends AdminAbstractController implements KernelControll
 
         $data = [];
         foreach (array_keys($dashboards) as $key) {
-            if ($key != 'welcome') {
+            if ($key !== 'welcome') {
                 $data[] = $key;
             }
         }
@@ -82,7 +72,7 @@ class PortalController extends AdminAbstractController implements KernelControll
     #[Route('/delete-dashboard', name: 'opendxp_admin_portal_deletedashboard', methods: ['DELETE'])]
     public function deleteDashboardAction(Request $request): JsonResponse
     {
-        $key = $request->get('key');
+        $key = $request->request->get('key');
         $this->dashboardHelper->deleteDashboard($key);
 
         return $this->adminJson(['success' => true]);
@@ -91,19 +81,25 @@ class PortalController extends AdminAbstractController implements KernelControll
     #[Route('/get-configuration', name: 'opendxp_admin_portal_getconfiguration', methods: ['GET'])]
     public function getConfigurationAction(Request $request): JsonResponse
     {
-        return $this->adminJson($this->getCurrentConfiguration($request));
+        $config = $this->dashboardHelper->getDashboard($request->query->get('key'));
+
+        return $this->adminJson($config);
     }
 
     #[Route('/remove-widget', name: 'opendxp_admin_portal_removewidget', methods: ['DELETE'])]
     public function removeWidgetAction(Request $request): JsonResponse
     {
-        $config = $this->getCurrentConfiguration($request);
+        $dashboardId = $request->request->get('key');
+        $config = $this->dashboardHelper->getDashboard($dashboardId);
+
         $newConfig = [[], []];
         $colCount = 0;
 
+        $currentId = $request->request->has('id') ? (int) $request->request->get('id') : null;
+
         foreach ($config['positions'] as $col) {
             foreach ($col as $row) {
-                if ($row['id'] != $request->get('id')) {
+                if ($row['id'] !== $currentId) {
                     $newConfig[$colCount][] = $row;
                 }
             }
@@ -111,7 +107,8 @@ class PortalController extends AdminAbstractController implements KernelControll
         }
 
         $config['positions'] = $newConfig;
-        $this->saveConfiguration($request, $config);
+
+        $this->dashboardHelper->saveDashboard($dashboardId, $config);
 
         return $this->adminJson(['success' => true]);
     }
@@ -119,7 +116,8 @@ class PortalController extends AdminAbstractController implements KernelControll
     #[Route('/add-widget', name: 'opendxp_admin_portal_addwidget', methods: ['POST'])]
     public function addWidgetAction(Request $request): JsonResponse
     {
-        $config = $this->getCurrentConfiguration($request);
+        $dashboardId = $request->request->get('key');
+        $config = $this->dashboardHelper->getDashboard($dashboardId);
 
         $nextId = 0;
         foreach ($config['positions'] as $col) {
@@ -129,9 +127,13 @@ class PortalController extends AdminAbstractController implements KernelControll
         }
 
         $nextId += 1;
-        $config['positions'][0][] = ['id' => $nextId, 'type' => $request->get('type'), 'config' => null];
+        $config['positions'][0][] = [
+            'id' => $nextId,
+            'type' => $request->request->get('type'),
+            'config' => null
+        ];
 
-        $this->saveConfiguration($request, $config);
+        $this->dashboardHelper->saveDashboard($dashboardId, $config);
 
         return $this->adminJson(['success' => true, 'id' => $nextId]);
     }
@@ -139,14 +141,18 @@ class PortalController extends AdminAbstractController implements KernelControll
     #[Route('/reorder-widget', name: 'opendxp_admin_portal_reorderwidget', methods: ['PUT'])]
     public function reorderWidgetAction(Request $request): JsonResponse
     {
-        $config = $this->getCurrentConfiguration($request);
+        $dashboardId = $request->request->get('key');
+        $config = $this->dashboardHelper->getDashboard($dashboardId);
+
         $newConfig = [[], []];
         $colCount = 0;
         $toMove = null;
 
+        $currentId = $request->request->has('id') ? (int) $request->request->get('id') : null;
+
         foreach ($config['positions'] as $col) {
             foreach ($col as $row) {
-                if ($row['id'] != $request->get('id')) {
+                if ($row['id'] !== $currentId) {
                     $newConfig[$colCount][] = $row;
                 } else {
                     $toMove = $row;
@@ -155,10 +161,11 @@ class PortalController extends AdminAbstractController implements KernelControll
             $colCount++;
         }
 
-        array_splice($newConfig[$request->get('column')], $request->request->getInt('row'), 0, [$toMove]);
+        array_splice($newConfig[$request->request->get('column')], $request->request->getInt('row'), 0, [$toMove]);
 
         $config['positions'] = $newConfig;
-        $this->saveConfiguration($request, $config);
+
+        $this->dashboardHelper->saveDashboard($dashboardId, $config);
 
         return $this->adminJson(['success' => true]);
     }
@@ -166,20 +173,22 @@ class PortalController extends AdminAbstractController implements KernelControll
     #[Route('/update-portlet-config', name: 'opendxp_admin_portal_updateportletconfig', methods: ['PUT'])]
     public function updatePortletConfigAction(Request $request): JsonResponse
     {
-        $key = $request->get('key');
-        $id = $request->get('id');
-        $configuration = $request->get('config');
+        $key = $request->request->get('key');
+
+        $currentId = $request->request->has('id') ? (int) $request->request->get('id') : null;
+        $configuration = $request->request->get('config');
 
         $dashboard = $this->dashboardHelper->getDashboard($key);
         foreach ($dashboard['positions'] as &$col) {
             foreach ($col as &$portlet) {
-                if ($portlet['id'] == $id) {
+                if ($portlet['id'] === $currentId) {
                     $portlet['config'] = $configuration;
 
                     break;
                 }
             }
         }
+
         $this->dashboardHelper->saveDashboard($key, $dashboard);
 
         return $this->adminJson(['success' => true]);

--- a/src/Controller/Admin/RecyclebinController.php
+++ b/src/Controller/Admin/RecyclebinController.php
@@ -34,8 +34,8 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
     #[Route('/recyclebin/list', name: 'opendxp_admin_recyclebin_list', methods: ['POST'])]
     public function listAction(Request $request): JsonResponse
     {
-        if ($request->get('xaction') === 'destroy') {
-            $item = Recyclebin\Item::getById(\OpenDxp\Bundle\AdminBundle\Helper\QueryParams::getRecordIdForGridRequest($request->get('data')));
+        if ($request->query->get('xaction') === 'destroy') {
+            $item = Recyclebin\Item::getById(\OpenDxp\Bundle\AdminBundle\Helper\QueryParams::getRecordIdForGridRequest($request->request->get('data')));
 
             if ($item) {
                 $item->delete();
@@ -47,13 +47,13 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
         $db = \OpenDxp\Db::get();
 
         $list = new Recyclebin\Item\Listing();
-        $list->setLimit((int) $request->get('limit', 50));
-        $list->setOffset((int) $request->get('start', 0));
+        $list->setLimit((int) $request->request->get('limit', 50));
+        $list->setOffset((int) $request->request->get('start', 0));
 
         $list->setOrderKey('date');
         $list->setOrder('DESC');
 
-        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings([...$request->request->all(), ...$request->query->all()]);
+        $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings($request->request->all());
         if ($sortingSettings['orderKey']) {
             $list->setOrderKey($sortingSettings['orderKey']);
             $list->setOrder($sortingSettings['order']);
@@ -61,11 +61,11 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
 
         $conditionFilters = [];
 
-        if ($request->get('filterFullText')) {
-            $conditionFilters[] = '`path` LIKE ' . $list->quote('%'. $list->escapeLike($request->get('filterFullText')) .'%');
+        if ($request->request->get('filterFullText')) {
+            $conditionFilters[] = '`path` LIKE ' . $list->quote('%'. $list->escapeLike($request->request->get('filterFullText')) .'%');
         }
 
-        $filters = $request->get('filter');
+        $filters = $request->request->get('filter');
         if ($filters) {
             $filters = $this->decodeJson($filters);
 
@@ -139,7 +139,7 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
     #[Route('/recyclebin/restore', name: 'opendxp_admin_recyclebin_restore', methods: ['POST'])]
     public function restoreAction(Request $request): JsonResponse
     {
-        $item = Recyclebin\Item::getById((int) $request->get('id'));
+        $item = Recyclebin\Item::getById((int) $request->request->get('id'));
         if (!$item) {
             throw $this->createNotFoundException();
         }

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -71,7 +71,7 @@ class SettingsController extends AdminAbstractController
     public function displayCustomLogoAction(Request $request): StreamedResponse
     {
         $mime = 'image/svg+xml';
-        if ($request->get('white')) {
+        if ($request->query->has('white')) {
             $logo = OPENDXP_WEB_ROOT . '/bundles/opendxpadmin/img/logo-claim-white.svg';
         } else {
             $logo = OPENDXP_WEB_ROOT . '/bundles/opendxpadmin/img/logo-claim-gray.svg';
@@ -141,9 +141,9 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('asset_metadata');
 
-        if ($request->get('data')) {
-            if ($request->get('xaction') == 'destroy') {
-                $data = $this->decodeJson($request->get('data'));
+        if ($request->request->has('data')) {
+            if ($request->query->get('xaction') === 'destroy') {
+                $data = $this->decodeJson($request->request->get('data'));
                 $id = $data['id'];
                 $metadata = Metadata\Predefined::getById($id);
                 if (!$metadata->isWriteable()) {
@@ -153,8 +153,9 @@ class SettingsController extends AdminAbstractController
 
                 return $this->adminJson(['success' => true, 'data' => []]);
             }
-            if ($request->get('xaction') == 'update') {
-                $data = $this->decodeJson($request->get('data'));
+
+            if ($request->query->get('xaction') === 'update') {
+                $data = $this->decodeJson($request->request->get('data'));
                 // save type
                 $metadata = Metadata\Predefined::getById($data['id']);
                 if (!$metadata->isWriteable()) {
@@ -173,11 +174,12 @@ class SettingsController extends AdminAbstractController
 
                 return $this->adminJson(['data' => $responseData, 'success' => true]);
             }
-            if ($request->get('xaction') == 'create') {
+
+            if ($request->query->get('xaction') === 'create') {
                 if (!(new Metadata\Predefined())->isWriteable()) {
                     throw new ConfigWriteException();
                 }
-                $data = $this->decodeJson($request->get('data'));
+                $data = $this->decodeJson($request->request->get('data'));
                 unset($data['id']);
                 // save type
                 $metadata = Metadata\Predefined::create();
@@ -196,7 +198,7 @@ class SettingsController extends AdminAbstractController
             // get list of types
             $list = new Metadata\Predefined\Listing();
 
-            if ($filter = $request->get('filter')) {
+            if ($filter = $request->request->get('filter')) {
                 $list->setFilter(function (Metadata\Predefined $predefined) use ($filter) {
                     foreach ($predefined->getObjectVars() as $value) {
                         if (stripos((string)$value, (string) $filter) !== false) {
@@ -225,9 +227,9 @@ class SettingsController extends AdminAbstractController
     #[Route('/get-predefined-metadata', name: 'opendxp_admin_settings_getpredefinedmetadata', methods: ['GET'])]
     public function getPredefinedMetadataAction(Request $request): JsonResponse
     {
-        $type = $request->get('type');
-        $subType = $request->get('subType');
-        $group = $request->get('group');
+        $type = $request->query->get('type');
+        $subType = $request->query->get('subType');
+        $group = $request->query->get('group');
         $list = Metadata\Predefined\Listing::getByTargetType($type, [$subType]);
         $result = [];
         foreach ($list as $item) {
@@ -248,9 +250,9 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('predefined_properties');
 
-        if ($request->get('data')) {
-            if ($request->get('xaction') == 'destroy') {
-                $data = $this->decodeJson($request->get('data'));
+        if ($request->request->has('data')) {
+            if ($request->query->get('xaction') === 'destroy') {
+                $data = $this->decodeJson($request->request->get('data'));
                 $id = $data['id'];
                 $property = Property\Predefined::getById($id);
                 if (!$property->isWriteable()) {
@@ -260,8 +262,9 @@ class SettingsController extends AdminAbstractController
 
                 return $this->adminJson(['success' => true, 'data' => []]);
             }
-            if ($request->get('xaction') == 'update') {
-                $data = $this->decodeJson($request->get('data'));
+
+            if ($request->query->get('xaction') === 'update') {
+                $data = $this->decodeJson($request->request->get('data'));
                 // save type
                 $property = Property\Predefined::getById($data['id']);
                 if (!$property->isWriteable()) {
@@ -278,11 +281,11 @@ class SettingsController extends AdminAbstractController
                 return $this->adminJson(['data' => $responseData, 'success' => true]);
             }
 
-            if ($request->get('xaction') == 'create') {
+            if ($request->query->get('xaction') === 'create') {
                 if (!(new Property\Predefined())->isWriteable()) {
                     throw new ConfigWriteException();
                 }
-                $data = $this->decodeJson($request->get('data'));
+                $data = $this->decodeJson($request->request->get('data'));
                 unset($data['id']);
                 // save type
                 $property = Property\Predefined::create();
@@ -297,7 +300,7 @@ class SettingsController extends AdminAbstractController
             // get list of types
             $list = new Property\Predefined\Listing();
 
-            if ($filter = $request->get('filter')) {
+            if ($filter = $request->request->get('filter')) {
                 $list->setFilter(function (Property\Predefined $predefined) use ($filter) {
                     foreach ($predefined->getObjectVars() as $value) {
                         if ($value) {
@@ -407,7 +410,7 @@ class SettingsController extends AdminAbstractController
     ): JsonResponse {
         $this->checkPermission('system_appearance_settings');
 
-        $values = $this->decodeJson($request->get('data'));
+        $values = $this->decodeJson($request->request->get('data'));
 
         $config->save($values);
 
@@ -439,7 +442,7 @@ class SettingsController extends AdminAbstractController
     ): JsonResponse {
         $this->checkPermission('system_settings');
 
-        $values = $this->decodeJson($request->get('data'));
+        $values = $this->decodeJson($request->request->get('data'));
 
         $config->save($values);
 
@@ -474,8 +477,8 @@ class SettingsController extends AdminAbstractController
             'success' => true,
         ];
 
-        $clearOpenDxpCache = !(bool)$request->get('only_symfony_cache');
-        $clearSymfonyCache = !(bool)$request->get('only_opendxp_cache');
+        $clearOpenDxpCache = !(bool)$request->request->get('only_symfony_cache');
+        $clearSymfonyCache = !(bool)$request->request->get('only_opendxp_cache');
 
         if ($clearOpenDxpCache) {
             $this->clearOpenDxpCache($cache, $eventDispatcher, $filesystem);
@@ -523,7 +526,7 @@ class SettingsController extends AdminAbstractController
     ): void {
         // pass one or move env parameters to clear multiple envs
         // if no env is passed it will use the current one
-        $environments = $request->get('env', $kernel->getEnvironment());
+        $environments = $request->request->get('env', $kernel->getEnvironment());
 
         if (!is_array($environments)) {
             $environments = trim((string)$environments);
@@ -629,7 +632,7 @@ class SettingsController extends AdminAbstractController
             return $this->adminJson([]);
         }
 
-        $excludeMainSite = $request->get('excludeMainSite');
+        $excludeMainSite = $request->query->get('excludeMainSite');
 
         $sitesList = new Model\Site\Listing();
         $sitesObjects = $sitesList->load();
@@ -778,14 +781,14 @@ class SettingsController extends AdminAbstractController
 
         $success = false;
 
-        $pipe = Asset\Image\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Image\Thumbnail\Config::getByName($request->request->get('name'));
 
         if (!$pipe) {
             $pipe = new Asset\Image\Thumbnail\Config();
             if (!$pipe->isWriteable()) {
                 throw new ConfigWriteException();
             }
-            $pipe->setName($request->get('name'));
+            $pipe->setName($request->request->get('name'));
             $pipe->save();
             $success = true;
         } elseif (!$pipe->isWriteable()) {
@@ -800,7 +803,7 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('thumbnails');
 
-        $pipe = Asset\Image\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Image\Thumbnail\Config::getByName($request->request->get('name'));
 
         if (!$pipe->isWriteable()) {
             throw new ConfigWriteException();
@@ -816,7 +819,7 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('thumbnails');
 
-        $pipe = Asset\Image\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Image\Thumbnail\Config::getByName($request->query->get('name'));
         $data = $pipe->getObjectVars();
         $data['writeable'] = $pipe->isWriteable();
 
@@ -828,15 +831,15 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('thumbnails');
 
-        $pipe = Asset\Image\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Image\Thumbnail\Config::getByName($request->request->get('name'));
 
         if (!$pipe->isWriteable()) {
             throw new ConfigWriteException();
         }
 
-        $settingsData = $this->decodeJson($request->get('settings'));
-        $mediaData = $this->decodeJson($request->get('medias'));
-        $mediaOrder = $this->decodeJson($request->get('mediaOrder'));
+        $settingsData = $this->decodeJson($request->request->get('settings'));
+        $mediaData = $this->decodeJson($request->request->get('medias'));
+        $mediaOrder = $this->decodeJson($request->request->get('mediaOrder'));
 
         foreach ($settingsData as $key => $value) {
             $setter = 'set' . ucfirst($key);
@@ -847,7 +850,7 @@ class SettingsController extends AdminAbstractController
 
         $pipe->resetItems();
 
-        uksort($mediaData, function ($a, $b) use ($mediaOrder) {
+        uksort($mediaData, static function ($a, $b) use ($mediaOrder) {
             if ($a === 'default') {
                 return -1;
             }
@@ -964,14 +967,14 @@ class SettingsController extends AdminAbstractController
 
         $success = false;
 
-        $pipe = Asset\Video\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Video\Thumbnail\Config::getByName($request->request->get('name'));
 
         if (!$pipe) {
             $pipe = new Asset\Video\Thumbnail\Config();
             if (!$pipe->isWriteable()) {
                 throw new ConfigWriteException();
             }
-            $pipe->setName($request->get('name'));
+            $pipe->setName($request->request->get('name'));
             $pipe->save();
             $success = true;
         } elseif (!$pipe->isWriteable()) {
@@ -986,7 +989,7 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('thumbnails');
 
-        $pipe = Asset\Video\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Video\Thumbnail\Config::getByName($request->request->get('name'));
 
         if (!$pipe->isWriteable()) {
             throw new ConfigWriteException();
@@ -1002,7 +1005,7 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('thumbnails');
 
-        $pipe = Asset\Video\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Video\Thumbnail\Config::getByName($request->query->get('name'));
 
         $data = $pipe->getObjectVars();
         $data['writeable'] = $pipe->isWriteable();
@@ -1015,15 +1018,15 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('thumbnails');
 
-        $pipe = Asset\Video\Thumbnail\Config::getByName($request->get('name'));
+        $pipe = Asset\Video\Thumbnail\Config::getByName($request->request->get('name'));
 
         if (!$pipe->isWriteable()) {
             throw new ConfigWriteException();
         }
 
-        $settingsData = $this->decodeJson($request->get('settings'));
-        $mediaData = $this->decodeJson($request->get('medias'));
-        $mediaOrder = $this->decodeJson($request->get('mediaOrder'));
+        $settingsData = $this->decodeJson($request->request->get('settings'));
+        $mediaData = $this->decodeJson($request->request->get('medias'));
+        $mediaOrder = $this->decodeJson($request->request->get('mediaOrder'));
 
         foreach ($settingsData as $key => $value) {
             $setter = 'set' . ucfirst($key);
@@ -1034,7 +1037,7 @@ class SettingsController extends AdminAbstractController
 
         $pipe->resetItems();
 
-        uksort($mediaData, function ($a, $b) use ($mediaOrder) {
+        uksort($mediaData, static function ($a, $b) use ($mediaOrder) {
             if ($a === 'default') {
                 return -1;
             }
@@ -1064,8 +1067,8 @@ class SettingsController extends AdminAbstractController
     {
         $this->checkPermission('website_settings');
 
-        if ($request->get('data')) {
-            $data = $this->decodeJson($request->get('data'));
+        if ($request->request->has('data')) {
+            $data = $this->decodeJson($request->request->get('data'));
 
             if (is_array($data)) {
                 foreach ($data as &$value) {
@@ -1075,7 +1078,7 @@ class SettingsController extends AdminAbstractController
                 }
             }
 
-            if ($request->get('xaction') == 'destroy') {
+            if ($request->query->get('xaction') === 'destroy') {
                 $id = $data['id'];
                 $setting = WebsiteSetting::getById($id);
                 if ($setting instanceof WebsiteSetting) {
@@ -1083,7 +1086,7 @@ class SettingsController extends AdminAbstractController
 
                     return $this->adminJson(['success' => true, 'data' => []]);
                 }
-            } elseif ($request->get('xaction') == 'update') {
+            } elseif ($request->query->get('xaction') === 'update') {
                 // save routes
                 $setting = WebsiteSetting::getById($data['id']);
                 if ($setting instanceof WebsiteSetting) {
@@ -1106,7 +1109,7 @@ class SettingsController extends AdminAbstractController
 
                     return $this->adminJson(['data' => $data, 'success' => true]);
                 }
-            } elseif ($request->get('xaction') == 'create') {
+            } elseif ($request->query->get('xaction') === 'create') {
                 unset($data['id']);
 
                 // save route
@@ -1120,8 +1123,8 @@ class SettingsController extends AdminAbstractController
         } else {
             $list = new WebsiteSetting\Listing();
 
-            $list->setLimit((int) $request->get('limit', 50));
-            $list->setOffset((int) $request->get('start', 0));
+            $list->setLimit((int) $request->request->get('limit', 50));
+            $list->setOffset((int) $request->request->get('start', 0));
 
             $sortingSettings = \OpenDxp\Bundle\AdminBundle\Helper\QueryParams::extractSortingSettings([...$request->request->all(), ...$request->query->all()]);
             if ($sortingSettings['orderKey']) {
@@ -1132,8 +1135,8 @@ class SettingsController extends AdminAbstractController
                 $list->setOrder('asc');
             }
 
-            if ($request->get('filter')) {
-                $list->setCondition('`name` LIKE ' . $list->quote('%'.$request->get('filter').'%'));
+            if ($request->request->has('filter')) {
+                $list->setCondition('`name` LIKE ' . $list->quote('%'.$request->request->get('filter').'%'));
             }
 
             $totalCount = $list->getTotalCount();

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -524,22 +524,11 @@ class SettingsController extends AdminAbstractController
         EventDispatcherInterface $eventDispatcher,
         CacheClearer $symfonyCacheClearer,
     ): void {
-        // pass one or move env parameters to clear multiple envs
+
         // if no env is passed it will use the current one
-        $environments = $request->request->get('env', $kernel->getEnvironment());
+        $environment = $request->request->get('env', $kernel->getEnvironment());
 
-        if (!is_array($environments)) {
-            $environments = trim((string)$environments);
-            $environments = empty($environments) ? [] : [$environments];
-        }
-
-        if ($environments === []) {
-            $environments = [$kernel->getEnvironment()];
-        }
-
-        $result['environments'] = $environments;
-
-        if (in_array($kernel->getEnvironment(), $environments)) {
+        if ($kernel->getEnvironment() === $environment) {
             // remove terminate and exception event listeners for the current env as they break with a
             // cleared container - see #2434
             foreach ($eventDispatcher->getListeners(KernelEvents::TERMINATE) as $listener) {
@@ -551,16 +540,7 @@ class SettingsController extends AdminAbstractController
             }
         }
 
-        foreach ($environments as $environment) {
-            try {
-                $symfonyCacheClearer->clear($environment);
-            } catch (Throwable $e) {
-                $errors = $result['errors'] ?? [];
-                $errors[] = $e->getMessage();
-
-                $result = [...$result, 'success' => false, 'errors' => $errors];
-            }
-        }
+        $symfonyCacheClearer->clear($environment);
     }
 
     #[Route('/clear-output-cache', name: 'opendxp_admin_settings_clearoutputcache', methods: ['DELETE'])]

--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -39,8 +39,8 @@ class TagsController extends AdminAbstractController
 
         try {
             $tag = new Tag();
-            $tag->setName(strip_tags($request->get('text', '')));
-            $tag->setParentId((int)$request->get('parentId'));
+            $tag->setName(strip_tags($request->request->get('text', '')));
+            $tag->setParentId((int)$request->request->get('parentId'));
             $tag->save();
 
             return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
@@ -57,14 +57,14 @@ class TagsController extends AdminAbstractController
     {
         $this->checkPermission('tags_configuration');
 
-        $tag = Tag::getById((int) $request->get('id'));
+        $tag = Tag::getById((int) $request->request->get('id'));
         if ($tag) {
             $tag->delete();
 
             return $this->adminJson(['success' => true]);
         }
 
-        throw $this->createNotFoundException('Tag with ID ' . $request->get('id') . ' not found.');
+        throw $this->createNotFoundException('Tag with ID ' . $request->request->get('id') . ' not found.');
     }
 
     /**
@@ -75,14 +75,14 @@ class TagsController extends AdminAbstractController
     {
         $this->checkPermission('tags_configuration');
 
-        $tag = Tag::getById((int) $request->get('id'));
+        $tag = Tag::getById((int) $request->request->get('id'));
         if ($tag) {
-            $parentId = $request->get('parentId');
+            $parentId = $request->request->get('parentId');
             if ($parentId || $parentId === '0') {
                 $tag->setParentId((int)$parentId);
             }
-            if ($request->get('text')) {
-                $tag->setName(strip_tags($request->get('text', '')));
+            if ($request->request->has('text')) {
+                $tag->setName(strip_tags($request->request->get('text', '')));
             }
 
             $tag->save();
@@ -90,15 +90,15 @@ class TagsController extends AdminAbstractController
             return $this->adminJson(['success' => true]);
         }
 
-        throw $this->createNotFoundException('Tag with ID ' . $request->get('id') . ' not found.');
+        throw $this->createNotFoundException('Tag with ID ' . $request->request->get('id') . ' not found.');
     }
 
     #[Route('/tree-get-children-by-id', name: 'opendxp_admin_tags_treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request): JsonResponse
     {
-        $showSelection = $request->get('showSelection') == 'true';
-        $assignmentCId = (int)$request->get('assignmentCId');
-        $assignmentCType = strip_tags($request->get('assignmentCType', ''));
+        $showSelection = $request->query->get('showSelection') === 'true';
+        $assignmentCId = (int)$request->query->get('assignmentCId');
+        $assignmentCType = strip_tags($request->query->get('assignmentCType', ''));
 
         $recursiveChildren = false;
         $assignedTagIds = [];
@@ -111,17 +111,17 @@ class TagsController extends AdminAbstractController
         }
 
         $tagList = new Tag\Listing();
-        if ($request->get('node')) {
-            $tagList->setCondition('parentId = ?', (int)$request->get('node'));
+        if ($request->query->get('node')) {
+            $tagList->setCondition('parentId = ?', (int)$request->query->get('node'));
         } else {
             $tagList->setCondition('ISNULL(parentId) OR parentId = 0');
         }
         $tagList->setOrderKey('name');
 
-        if (!empty($request->get('filter'))) {
+        if (!empty($request->query->get('filter'))) {
             $filterIds = [0];
             $filterTagList = new Tag\Listing();
-            $filterTagList->setCondition('LOWER(`name`) LIKE ?', ['%' . $filterTagList->escapeLike(mb_strtolower($request->get('filter'))) . '%']);
+            $filterTagList->setCondition('LOWER(`name`) LIKE ?', ['%' . $filterTagList->escapeLike(mb_strtolower($request->query->get('filter'))) . '%']);
             foreach ($filterTagList->load() as $filterTag) {
                 if ($filterTag->getParentId() === 0) {
                     $filterIds[] = $filterTag->getId();
@@ -180,12 +180,12 @@ class TagsController extends AdminAbstractController
     #[Route('/load-tags-for-element', name: 'opendxp_admin_tags_loadtagsforelement', methods: ['GET'])]
     public function loadTagsForElementAction(Request $request): JsonResponse
     {
-        $assginmentCId = (int)$request->get('assignmentCId');
-        $assginmentCType = strip_tags($request->get('assignmentCType', ''));
+        $assignmentId = (int)$request->query->get('assignmentCId');
+        $assignmentType = strip_tags($request->query->get('assignmentCType', ''));
 
         $assignedTagArray = [];
-        if ($assginmentCId && $assginmentCType) {
-            $assignedTags = Tag::getTagsForElement($assginmentCType, $assginmentCId);
+        if ($assignmentId && $assignmentType) {
+            $assignedTags = Tag::getTagsForElement($assignmentType, $assignmentId);
 
             foreach ($assignedTags as $assignedTag) {
                 $assignedTagArray[] = $this->convertTagToArray($assignedTag, false, []);
@@ -198,13 +198,13 @@ class TagsController extends AdminAbstractController
     #[Route('/add-tag-to-element', name: 'opendxp_admin_tags_addtagtoelement', methods: ['PUT'])]
     public function addTagToElementAction(Request $request): JsonResponse
     {
-        $assginmentCId = (int)$request->get('assignmentElementId');
-        $assginmentCType = strip_tags($request->get('assignmentElementType', ''));
-        $tagId = (int)$request->get('tagId');
+        $assignmentElementId = (int)$request->request->get('assignmentElementId');
+        $assignmentElementType = strip_tags($request->request->get('assignmentElementType', ''));
+        $tagId = (int)$request->request->get('tagId');
 
         $tag = Tag::getById($tagId);
         if ($tag) {
-            Tag::addTagToElement($assginmentCType, $assginmentCId, $tag);
+            Tag::addTagToElement($assignmentElementType, $assignmentElementId, $tag);
 
             return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
         }
@@ -215,13 +215,13 @@ class TagsController extends AdminAbstractController
     #[Route('/remove-tag-from-element', name: 'opendxp_admin_tags_removetagfromelement', methods: ['DELETE'])]
     public function removeTagFromElementAction(Request $request): JsonResponse
     {
-        $assginmentCId = (int)$request->get('assignmentElementId');
-        $assginmentCType = strip_tags($request->get('assignmentElementType', ''));
-        $tagId = (int)$request->get('tagId');
+        $assignmentElementId = (int)$request->request->get('assignmentElementId');
+        $assignmentElementType = strip_tags($request->request->get('assignmentElementType', ''));
+        $tagId = (int)$request->request->get('tagId');
 
         $tag = Tag::getById($tagId);
         if ($tag) {
-            Tag::removeTagFromElement($assginmentCType, $assginmentCId, $tag);
+            Tag::removeTagFromElement($assignmentElementType, $assignmentElementId, $tag);
 
             return $this->adminJson(['success' => true, 'id' => $tag->getId()]);
         }
@@ -232,8 +232,8 @@ class TagsController extends AdminAbstractController
     #[Route('/get-batch-assignment-jobs', name: 'opendxp_admin_tags_getbatchassignmentjobs', methods: ['GET'])]
     public function getBatchAssignmentJobsAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
-        $elementId = (int)$request->get('elementId');
-        $elementType = strip_tags($request->get('elementType', ''));
+        $elementId = (int)$request->query->get('elementId');
+        $elementType = strip_tags($request->query->get('elementType', ''));
 
         $idList = [];
         switch ($elementType) {
@@ -324,6 +324,7 @@ class TagsController extends AdminAbstractController
             'list' => $childrenList,
             'context' => [],
         ]);
+
         $eventDispatcher->dispatch($beforeListLoadEvent, AdminEvents::ASSET_LIST_BEFORE_LIST_LOAD);
         /** @var \OpenDxp\Model\Asset\Listing $childrenList */
         $childrenList = $beforeListLoadEvent->getArgument('list');
@@ -364,10 +365,10 @@ class TagsController extends AdminAbstractController
     #[Route('/do-batch-assignment', name: 'opendxp_admin_tags_dobatchassignment', methods: ['PUT'])]
     public function doBatchAssignmentAction(Request $request): JsonResponse
     {
-        $cType = strip_tags($request->get('elementType', ''));
-        $assignedTags = json_decode($request->get('assignedTags'));
-        $elementIds = json_decode($request->get('childrenIds'));
-        $doCleanupTags = $request->get('removeAndApply') == 'true';
+        $cType = strip_tags($request->request->get('elementType', ''));
+        $assignedTags = json_decode($request->request->get('assignedTags'));
+        $elementIds = json_decode($request->request->get('childrenIds'));
+        $doCleanupTags = $request->request->get('removeAndApply') === 'true';
 
         Tag::batchAssignTagsToElement($cType, $elementIds, $assignedTags, $doCleanupTags);
 

--- a/src/Controller/Admin/TranslationController.php
+++ b/src/Controller/Admin/TranslationController.php
@@ -31,6 +31,7 @@ use OpenDxp\Tool;
 use OpenDxp\Tool\Session;
 use OpenDxp\Translation\Translator;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -44,15 +45,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[Route('/translation')]
 class TranslationController extends AdminAbstractController
 {
-    protected const PLACEHOLDER_NAME = 'placeHolder';
+    protected const string PLACEHOLDER_NAME = 'placeHolder';
 
     #[Route('/import', name: 'opendxp_admin_translation_import', methods: ['POST'])]
     public function importAction(Request $request, LocaleServiceInterface $localeService): JsonResponse
     {
-        $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
+        $domain = $request->request->get('domain', Translation::DOMAIN_DEFAULT);
         $admin = $domain == Translation::DOMAIN_ADMIN;
 
-        $dialect = $request->get('csvSettings');
+        $dialect = $request->request->get('csvSettings');
         $session = Session::getSessionBag($request->getSession(), 'opendxp_importconfig');
         $tmpFile = $session->get('translation_import_file');
 
@@ -62,7 +63,7 @@ class TranslationController extends AdminAbstractController
 
         $this->checkPermission(($admin ? 'admin_' : '') . 'translations');
 
-        $merge = $request->get('merge');
+        $merge = $request->query->get('merge');
         $overwrite = !$merge;
 
         $allowedLanguages = $this->getAdminUser()->getAllowedLanguagesForEditingWebsiteTranslations();
@@ -111,14 +112,17 @@ class TranslationController extends AdminAbstractController
     #[Route('/upload-import', name: 'opendxp_admin_translation_uploadimportfile', methods: ['POST'])]
     public function uploadImportFileAction(Request $request, Filesystem $filesystem): JsonResponse
     {
-        $tmpData = file_get_contents($_FILES['Filedata']['tmp_name']);
+        /** @var UploadedFile $file */
+        $file = $request->files->get('Filedata');
+
+        $tmpData = file_get_contents($file->getPathname());
 
         //store data for further usage
-        $filename = uniqid('import_translations-');
+        $filename = uniqid('import_translations-', false);
         $importFile = OPENDXP_SYSTEM_TEMP_DIRECTORY . '/' . $filename;
         $filesystem->dumpFile($importFile, $tmpData);
 
-        Session::useBag($request->getSession(), function (AttributeBagInterface $session) use ($importFile): void {
+        Session::useBag($request->getSession(), static function (AttributeBagInterface $session) use ($importFile): void {
             $session->set('translation_import_file', $importFile);
         }, 'opendxp_importconfig');
 
@@ -141,7 +145,7 @@ class TranslationController extends AdminAbstractController
     #[Route('/export', name: 'opendxp_admin_translation_export', methods: ['GET'])]
     public function exportAction(Request $request): Response
     {
-        $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
+        $domain = $request->query->get('domain', Translation::DOMAIN_DEFAULT);
         $admin = $domain == Translation::DOMAIN_ADMIN;
 
         $this->checkPermission(($admin ? 'admin_' : '') . 'translations');
@@ -266,7 +270,8 @@ class TranslationController extends AdminAbstractController
     #[Route('/add-admin-translation-keys', name: 'opendxp_admin_translation_addadmintranslationkeys', methods: ['POST'])]
     public function addAdminTranslationKeysAction(Request $request): JsonResponse
     {
-        $keys = $request->get('keys');
+        $keys = $request->request->get('keys');
+
         if ($keys) {
             $availableLanguages = Tool\Admin::getLanguages();
             $data = $this->decodeJson($keys);
@@ -307,7 +312,7 @@ class TranslationController extends AdminAbstractController
     #[Route('/translations', name: 'opendxp_admin_translation_translations', methods: ['POST'])]
     public function translationsAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
-        $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
+        $domain = $request->request->get('domain', Translation::DOMAIN_DEFAULT);
         $admin = $domain === Translation::DOMAIN_ADMIN;
 
         $this->checkPermission(($admin ? 'admin_' : '') . 'translations');
@@ -319,10 +324,10 @@ class TranslationController extends AdminAbstractController
         // clear translation cache
         Translation::clearDependentCache();
 
-        if ($request->get('data')) {
-            $data = $this->decodeJson($request->get('data'));
+        if ($request->request->has('data')) {
+            $data = $this->decodeJson($request->request->get('data'));
 
-            if ($request->get('xaction') === 'destroy') {
+            if ($request->query->get('xaction') === 'destroy') {
                 $t = Translation::getByKey($data['key'], $domain);
                 if ($t instanceof Translation) {
                     $t->delete();
@@ -331,7 +336,7 @@ class TranslationController extends AdminAbstractController
                 return $this->adminJson(['success' => true, 'data' => []]);
             }
 
-            if ($request->get('xaction') === 'update') {
+            if ($request->query->get('xaction') === 'update') {
                 $t = Translation::getByKey($data['key'], $domain);
 
                 foreach ($data as $key => $value) {
@@ -356,7 +361,7 @@ class TranslationController extends AdminAbstractController
                 return $this->adminJson(['data' => $return, 'success' => true]);
             }
 
-            if ($request->get('xaction') === 'create') {
+            if ($request->query->get('xaction') === 'create') {
                 $t = Translation::getByKey($data['key'], $domain);
                 if ($t) {
                     return $this->adminJson([
@@ -413,8 +418,8 @@ class TranslationController extends AdminAbstractController
                 $list->setOrder($sortingSettings['order']);
             }
 
-            $list->setLimit((int) $request->get('limit', 50));
-            $list->setOffset((int) $request->get('start', 0));
+            $list->setLimit((int) $request->request->get('limit', 50));
+            $list->setOffset((int) $request->request->get('start', 0));
 
             $conditions = $this->getGridFilterCondition($request, $tableName, false, $admin);
             $filters = $this->getGridFilterCondition($request, $tableName, true, $admin);
@@ -432,7 +437,7 @@ class TranslationController extends AdminAbstractController
             $list->load();
 
             $translations = [];
-            $searchString = $request->get('searchString');
+            $searchString = $request->request->get('searchString');
             foreach ($list->getTranslations() as $t) {
                 //Reload translation to get complete data,
                 //if translation fetched based on the text not key
@@ -512,7 +517,7 @@ class TranslationController extends AdminAbstractController
         $db = \OpenDxp\Db::get();
         $conditionFilters = [];
 
-        $filterJson = $request->get('filter');
+        $filterJson = $request->request->get('filter');
         if ($filterJson) {
             $propertyField = 'property';
             $operatorField = 'operator';
@@ -540,17 +545,17 @@ class TranslationController extends AdminAbstractController
                 }
 
                 if (!empty($filter['value'])) {
-                    if ($filter['type'] == 'string') {
+                    if ($filter['type'] === 'string') {
                         $operator = 'LIKE';
                         $field = $fieldname;
                         $value = '%' . $filter['value'] . '%';
-                    } elseif ($filter['type'] == 'date' ||
+                    } elseif ($filter['type'] === 'date' ||
                         (in_array($fieldname, ['modificationDate', 'creationDate']))) {
-                        if ($filter[$operatorField] == 'lt') {
+                        if ($filter[$operatorField] === 'lt') {
                             $operator = '<';
-                        } elseif ($filter[$operatorField] == 'gt') {
+                        } elseif ($filter[$operatorField] === 'gt') {
                             $operator = '>';
-                        } elseif ($filter[$operatorField] == 'eq') {
+                        } elseif ($filter[$operatorField] === 'eq') {
                             $operator = '=';
                             $fieldname = "UNIX_TIMESTAMP(DATE(FROM_UNIXTIME({$fieldname})))";
                         }
@@ -581,11 +586,11 @@ class TranslationController extends AdminAbstractController
             }
         }
 
-        if ($request->get('searchString')) {
+        if ($request->request->get('searchString')) {
             $conditionFilters[] = [
                 'condition' => '(lower(' . $tableName . '.key) LIKE :filterTerm OR lower(' . $tableName . '.text) LIKE :filterTerm)',
                 'field' => 'filterTerm',
-                'value' => '%' . mb_strtolower($request->get('searchString')) . '%',
+                'value' => '%' . mb_strtolower($request->request->get('searchString')) . '%',
             ];
         }
 
@@ -616,7 +621,7 @@ class TranslationController extends AdminAbstractController
     #[Route('/cleanup', name: 'opendxp_admin_translation_cleanup', methods: ['DELETE'])]
     public function cleanupAction(Request $request): JsonResponse
     {
-        $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
+        $domain = $request->request->get('domain', Translation::DOMAIN_DEFAULT);
         $list = new Translation\Listing();
         $list->setDomain($domain);
         $list->cleanup();
@@ -635,14 +640,14 @@ class TranslationController extends AdminAbstractController
     #[Route('/content-export-jobs', name: 'opendxp_admin_translation_contentexportjobs', methods: ['POST'])]
     public function contentExportJobsAction(Request $request): JsonResponse
     {
-        $data = $this->decodeJson($request->get('data'));
+        $data = $this->decodeJson($request->request->get('data'));
         $elements = [];
         $jobs = [];
-        $exportId = uniqid();
-        $source = $request->get('source', '');
-        $target = $request->get('target', '');
-        $type = $request->get('type');
-        $jobUrl = $request->get('job_url', $request->getBaseUrl() . '/admin/translation/' . $type . '-export');
+        $exportId = uniqid('', false);
+        $source = $request->request->get('source', '');
+        $target = $request->request->get('target', '');
+        $type = $request->request->get('type');
+        $jobUrl = $request->request->get('job_url', $request->getBaseUrl() . '/admin/translation/' . $type . '-export');
 
         $source = str_replace('_', '-', $source);
         $target = str_replace('_', '-', $target);
@@ -686,7 +691,7 @@ class TranslationController extends AdminAbstractController
                         if (isset($element['relations']) && $element['relations']) {
                             $childDependencies = $child->getDependencies()->getRequires();
                             foreach ($childDependencies as $cd) {
-                                if ($cd['type'] == 'object' || $cd['type'] == 'document') {
+                                if ($cd['type'] === 'object' || $cd['type'] === 'document') {
                                     $elements[$cd['type'] . '_' . $cd['id']] = $cd;
                                 }
                             }
@@ -701,7 +706,7 @@ class TranslationController extends AdminAbstractController
 
                     $dependencies = $el->getDependencies()->getRequires();
                     foreach ($dependencies as $dependency) {
-                        if ($dependency['type'] == 'object' || $dependency['type'] == 'document') {
+                        if ($dependency['type'] === 'object' || $dependency['type'] === 'document') {
                             $elements[$dependency['type'] . '_' . $dependency['id']] = $dependency;
                         }
                     }
@@ -711,7 +716,7 @@ class TranslationController extends AdminAbstractController
 
         $elements = array_values($elements);
 
-        $elementsPerJob = (int)$request->get('elements_per_job', 10);
+        $elementsPerJob = (int)$request->request->get('elements_per_job', 10);
 
         // make sure elements per job is not 0
         if (!$elementsPerJob) {
@@ -733,21 +738,19 @@ class TranslationController extends AdminAbstractController
             ]];
         }
 
-        return $this->adminJson(
-            [
-                'success' => true,
-                'jobs' => $jobs,
-                'id' => $exportId,
-            ]
-        );
+        return $this->adminJson([
+            'success' => true,
+            'jobs'    => $jobs,
+            'id'      => $exportId,
+        ]);
     }
 
     #[Route('/merge-item', name: 'opendxp_admin_translation_mergeitem', methods: ['PUT'])]
     public function mergeItemAction(Request $request): JsonResponse
     {
-        $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
+        $domain = $request->request->get('domain', Translation::DOMAIN_DEFAULT);
 
-        $dataList = json_decode($request->get('data'), true);
+        $dataList = json_decode($request->request->get('data'), true);
 
         foreach ($dataList as $data) {
             $t = Translation::getByKey($data['key'], $domain, true);
@@ -757,25 +760,20 @@ class TranslationController extends AdminAbstractController
             $t->save();
         }
 
-        return $this->adminJson(
-            [
-                'success' => true,
-            ]
-        );
+        return $this->adminJson([
+            'success' => true,
+        ]);
     }
 
     #[Route('/get-website-translation-languages', name: 'opendxp_admin_translation_getwebsitetranslationlanguages', methods: ['GET'])]
     public function getWebsiteTranslationLanguagesAction(Request $request): JsonResponse
     {
-        return $this->adminJson(
-            [
-                'view' => $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations(),
-
-                //when no view language is defined, all languages are editable. if one view language is defined, it
-                //may be possible that no edit language is set intentionally
-                'edit' => $this->getAdminUser()->getAllowedLanguagesForEditingWebsiteTranslations(),
-            ]
-        );
+        return $this->adminJson([
+            'view' => $this->getAdminUser()->getAllowedLanguagesForViewingWebsiteTranslations(),
+            //when no view language is defined, all languages are editable. if one view language is defined, it
+            //may be possible that no edit language is set intentionally
+            'edit' => $this->getAdminUser()->getAllowedLanguagesForEditingWebsiteTranslations(),
+        ]);
     }
 
     #[Route('/get-translation-domains', name: 'opendxp_admin_translation_gettranslationdomains', methods: ['GET'])]
@@ -784,7 +782,7 @@ class TranslationController extends AdminAbstractController
         $translation = new Translation();
 
         $domains = array_map(
-            fn ($domain) => ['name' => $domain],
+            static fn ($domain) => ['name' => $domain],
             $translation->getDao()->getAvailableDomains(),
         );
 

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -52,7 +52,7 @@ class UserController extends AdminAbstractController implements KernelController
     public function treeGetChildrenByIdAction(Request $request): JsonResponse
     {
         $list = new User\Listing();
-        $list->setCondition('parentId = ?', (int)$request->get('node'));
+        $list->setCondition('parentId = ?', (int)$request->query->get('node'));
         $list->setOrder('ASC');
         $list->setOrderKey('name');
         $list->load();
@@ -118,8 +118,8 @@ class UserController extends AdminAbstractController implements KernelController
                 'active' => $request->request->getBoolean('active'),
             ]);
 
-            if ($request->get('rid')) {
-                $rid = (int)$request->get('rid');
+            if ($request->request->has('rid')) {
+                $rid = (int)$request->request->get('rid');
                 $rObject = $className::getById($rid);
                 if ($rObject && ($type === 'user' || $type === 'role')) {
                     $user->setParentId($rObject->getParentId());
@@ -217,7 +217,7 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/delete', name: 'opendxp_admin_user_delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
-        $user = User\AbstractUser::getById((int)$request->get('id'));
+        $user = User\AbstractUser::getById((int)$request->request->get('id'));
 
         // only admins are allowed to delete admins and folders
         // because a folder might contain an admin user, so it is simply not allowed for users with the "users" permission
@@ -259,8 +259,8 @@ class UserController extends AdminAbstractController implements KernelController
             throw $this->createAccessDeniedHttpException('Only admin users are allowed to modify admin users');
         }
 
-        if ($request->get('data')) {
-            $values = $this->decodeJson($request->get('data'), true);
+        if ($request->request->has('data')) {
+            $values = $this->decodeJson($request->request->get('data'), true);
 
             if (!empty($values['password'])) {
                 if (strlen($values['password']) < 10) {
@@ -301,9 +301,9 @@ class UserController extends AdminAbstractController implements KernelController
             }
 
             // check for workspaces
-            if ($request->get('workspaces')) {
+            if ($request->request->has('workspaces')) {
                 $processedPaths = ['object' => [], 'asset' => [], 'document' => []]; //array to find if there are multiple entries for a path
-                $workspaces = $this->decodeJson($request->get('workspaces'), true);
+                $workspaces = $this->decodeJson($request->request->get('workspaces'), true);
                 foreach ($workspaces as $type => $spaces) {
                     $newWorkspaces = [];
                     foreach ($spaces as $space) {
@@ -330,8 +330,8 @@ class UserController extends AdminAbstractController implements KernelController
             }
         }
 
-        if ($user instanceof User && $request->get('keyBindings')) {
-            $keyBindings = json_decode($request->get('keyBindings'), true);
+        if ($user instanceof User && $request->request->has('keyBindings')) {
+            $keyBindings = json_decode($request->request->get('keyBindings'), true);
             $tmpArray = [];
             foreach ($keyBindings as $item) {
                 $tmpArray[] = json_decode($item, true);
@@ -353,7 +353,7 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/get', name: 'opendxp_admin_user_get', methods: ['GET'])]
     public function getAction(Request $request): JsonResponse
     {
-        $userId = (int)$request->get('id');
+        $userId = (int)$request->query->get('id');
         if ($userId < 1) {
             throw $this->createNotFoundException();
         }
@@ -452,7 +452,7 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/get-minimal', name: 'opendxp_admin_user_getminimal', methods: ['GET'])]
     public function getMinimalAction(Request $request): JsonResponse
     {
-        $user = User::getById((int)$request->get('id'));
+        $user = User::getById((int)$request->query->get('id'));
 
         if (!$user) {
             throw $this->createNotFoundException();
@@ -472,10 +472,13 @@ class UserController extends AdminAbstractController implements KernelController
     public function uploadCurrentUserImageAction(Request $request): JsonResponse
     {
         $user = $this->getAdminUser();
-        if ($user != null) {
-            if ($user->getId() == $request->get('id')) {
+
+        if ($user !== null) {
+
+            if ($user->getId() === (int)$request->query->get('id')) {
                 return $this->uploadImageAction($request);
             }
+
             Logger::warn('prevented save current user, because ids do not match. ');
 
             return $this->adminJson(false);
@@ -490,11 +493,11 @@ class UserController extends AdminAbstractController implements KernelController
         //TODO Can be completely validated with Symfony Validator
         $user = $this->getAdminUser();
 
-        $isPasswordReset = Tool\Session::useBag($request->getSession(), fn (AttributeBagInterface $adminSession) => (bool) $adminSession->get('password_reset'));
+        $isPasswordReset = Tool\Session::useBag($request->getSession(), static fn (AttributeBagInterface $adminSession) => (bool) $adminSession->get('password_reset'));
 
-        if ($user != null) {
-            if ($user->getId() == $request->get('id')) {
-                $values = $this->decodeJson($request->get('data'), true);
+        if ($user !== null && $request->request->has('id')) {
+            if ($user->getId() === (int) $request->request->get('id')) {
+                $values = $this->decodeJson($request->request->get('data'), true);
 
                 unset($values['name'], $values['id'], $values['admin'], $values['permissions'], $values['roles'], $values['active']);
 
@@ -534,8 +537,8 @@ class UserController extends AdminAbstractController implements KernelController
 
                 $user->setValues($values);
 
-                if ($request->get('keyBindings')) {
-                    $keyBindings = json_decode($request->get('keyBindings'), true);
+                if ($request->request->has('keyBindings')) {
+                    $keyBindings = json_decode($request->request->get('keyBindings'), true);
                     $tmpArray = [];
                     foreach ($keyBindings as $item) {
                         $tmpArray[] = json_decode($item, true);
@@ -598,7 +601,7 @@ class UserController extends AdminAbstractController implements KernelController
     public function roleTreeGetChildrenByIdAction(Request $request): JsonResponse
     {
         $list = new User\Role\Listing();
-        $list->setCondition('parentId = ?', (int)$request->get('node'));
+        $list->setCondition('parentId = ?', (int)$request->query->get('node'));
         $list->load();
 
         $roles = [];
@@ -644,7 +647,7 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/role-get', name: 'opendxp_admin_user_roleget', methods: ['GET'])]
     public function roleGetAction(Request $request): JsonResponse
     {
-        $role = User\Role::getById((int)$request->get('id'));
+        $role = User\Role::getById((int)$request->query->get('id'));
 
         if (!$role) {
             throw $this->createNotFoundException();
@@ -694,7 +697,8 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/upload-image', name: 'opendxp_admin_user_uploadimage', methods: ['POST'])]
     public function uploadImageAction(Request $request): JsonResponse
     {
-        $userObj = User::getById($this->getUserId($request));
+        $requestUserId = $request->query->has('id') ? (int)$request->query->get('id') : null;
+        $userObj = User::getById($this->getUserId($requestUserId));
 
         if (!$userObj) {
             throw $this->createNotFoundException();
@@ -713,7 +717,7 @@ class UserController extends AdminAbstractController implements KernelController
             throw new Exception('Unsupported file format.');
         }
 
-        $userObj->setImage($_FILES['Filedata']['tmp_name']);
+        $userObj->setImage($avatarFile->getPathname());
 
         // set content-type to text/html, otherwise (when application/json is sent) chrome will complain in
         // Ext.form.Action.Submit and mark the submission as failed
@@ -730,7 +734,8 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/delete-image', name: 'opendxp_admin_user_deleteimage', methods: ['DELETE'])]
     public function deleteImageAction(Request $request): JsonResponse
     {
-        $userObj = User::getById($this->getUserId($request));
+        $requestUserId = $request->query->has('id') ? (int)$request->query->get('id') : null;
+        $userObj = User::getById($this->getUserId($requestUserId));
 
         if (!$userObj) {
             throw $this->createNotFoundException();
@@ -774,10 +779,12 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/reset-2fa-secret', name: 'opendxp_admin_user_reset2fasecret', methods: ['PUT'])]
     public function reset2FaSecretAction(Request $request): JsonResponse
     {
-        $user = User::getById((int)$request->get('id'));
+        $user = User::getById((int)$request->request->get('id'));
+
         if (!$user) {
             throw $this->createNotFoundException();
         }
+
         $user->setTwoFactorAuthentication('enabled', false);
         $user->setTwoFactorAuthentication('secret', '');
         $user->save();
@@ -804,7 +811,9 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/get-image', name: 'opendxp_admin_user_getimage', methods: ['GET'])]
     public function getImageAction(Request $request): StreamedResponse
     {
-        $userObj = User::getById($this->getUserId($request));
+        $requestUserId = $request->query->has('id') ? (int)$request->query->get('id') : null;
+        $userObj = User::getById($this->getUserId($requestUserId));
+
         if (!$userObj) {
             throw $this->createNotFoundException();
         }
@@ -823,7 +832,7 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/get-token-login-link', name: 'opendxp_admin_user_gettokenloginlink', methods: ['GET'])]
     public function getTokenLoginLinkAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
-        $user = User::getById((int) $request->get('id'));
+        $user = User::getById((int) $request->query->get('id'));
 
         if (!$user) {
             return $this->adminJson([
@@ -860,13 +869,12 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/search', name: 'opendxp_admin_user_search', methods: ['GET'])]
     public function searchAction(Request $request): JsonResponse
     {
-        $q = '%' . $request->get('query') . '%';
+        $q = '%' . $request->query->get('query') . '%';
 
         $list = new User\Listing();
-        $list->setCondition('name LIKE ? OR firstname LIKE ? OR lastname LIKE ? OR email LIKE ? OR id = ?', [$q, $q, $q, $q, (int)$request->get('query')]);
+        $list->setCondition('name LIKE ? OR firstname LIKE ? OR lastname LIKE ? OR email LIKE ? OR id = ?', [$q, $q, $q, $q, (int)$request->query->get('query')]);
         $list->setOrder('ASC');
         $list->setOrderKey('name');
-        $list->load();
 
         $users = [];
         foreach ($list->getUsers() as $user) {
@@ -929,7 +937,7 @@ class UserController extends AdminAbstractController implements KernelController
 
         $conditions = [ 'type = "user"' ];
 
-        if (!$request->get('include_current_user')) {
+        if (!$request->query->get('include_current_user')) {
             $conditions[] = 'id != ' . $this->getAdminUser()->getId();
         }
 
@@ -939,7 +947,7 @@ class UserController extends AdminAbstractController implements KernelController
         $userList = $list->getUsers();
 
         foreach ($userList as $user) {
-            if (!$request->get('permission') || $user->isAllowed($request->get('permission'))) {
+            if (!$request->query->get('permission') || $user->isAllowed($request->query->get('permission'))) {
                 $users[] = [
                     'id' => $user->getId(),
                     'label' => $user->getUsername(),
@@ -961,7 +969,7 @@ class UserController extends AdminAbstractController implements KernelController
         $roleList = $list->getRoles();
 
         foreach ($roleList as $role) {
-            if (!$request->get('permission') || in_array($request->get('permission'), $role->getPermissions())) {
+            if (!$request->query->has('permission') || in_array($request->query->get('permission'), $role->getPermissions())) {
                 $roles[] = [
                     'id' => $role->getId(),
                     'label' => $role->getName(),
@@ -987,7 +995,7 @@ class UserController extends AdminAbstractController implements KernelController
         $success = false;
         $message = '';
 
-        if ($username = $request->get('username')) {
+        if ($username = $request->request->get('username')) {
             $user = User::getByName($username);
             if ($user instanceof User) {
                 if (!$user->isActive()) {
@@ -1043,17 +1051,20 @@ class UserController extends AdminAbstractController implements KernelController
         ]);
     }
 
-    protected function getUserId(Request $request): int
+    protected function getUserId(?int $requestedUserId): int
     {
-        if ($request->get('id')) {
-            if ($this->getAdminUser()->getId() != $request->get('id')) {
+        $currentAdminUserId = $this->getAdminUser()->getId();
+
+        if ($requestedUserId !== null) {
+
+            if ($currentAdminUserId !== $requestedUserId) {
                 $this->checkPermission('users');
             }
 
-            return (int) $request->get('id');
+            return $requestedUserId;
         }
 
-        return $this->getAdminUser()->getId();
+        return $currentAdminUserId;
     }
 
     /**

--- a/src/Controller/Admin/WorkflowController.php
+++ b/src/Controller/Admin/WorkflowController.php
@@ -57,11 +57,11 @@ class WorkflowController extends AdminAbstractController implements KernelContro
     /**
      * Returns a JSON of the available workflow actions to the admin panel
      */
-    #[Route('/get-workflow-form', name: 'opendxp_admin_workflow_getworkflowform')]
+    #[Route('/get-workflow-form', name: 'opendxp_admin_workflow_getworkflowform', methods: ['POST'])]
     public function getWorkflowFormAction(Request $request, Manager $workflowManager): JsonResponse
     {
         try {
-            $workflow = $workflowManager->getWorkflowIfExists($this->element, (string) $request->get('workflowName'));
+            $workflow = $workflowManager->getWorkflowIfExists($this->element, (string) $request->request->get('workflowName'));
 
             if (empty($workflow)) {
                 $wfConfig = [
@@ -79,13 +79,13 @@ class WorkflowController extends AdminAbstractController implements KernelContro
                 $enabledTransitions = $workflow->getEnabledTransitions($this->element);
                 $transition = null;
                 foreach ($enabledTransitions as $_transition) {
-                    if ($_transition->getName() === $request->get('transitionName')) {
+                    if ($_transition->getName() === $request->request->get('transitionName')) {
                         $transition = $_transition;
                     }
                 }
 
                 if (!$transition instanceof Transition) {
-                    $wfConfig['message'] = sprintf('transition %s currently not allowed', (string) $request->get('transitionName'));
+                    $wfConfig['message'] = sprintf('transition %s currently not allowed', (string) $request->request->get('transitionName'));
                 } else {
                     $wfConfig['notes_required'] = $transition->getNotesCommentRequired();
                     $wfConfig['additional_fields'] = [];
@@ -101,12 +101,12 @@ class WorkflowController extends AdminAbstractController implements KernelContro
     #[Route('/submit-workflow-transition', name: 'opendxp_admin_workflow_submitworkflowtransition', methods: ['POST'])]
     public function submitWorkflowTransitionAction(Request $request, Registry $workflowRegistry, Manager $workflowManager): JsonResponse
     {
-        $workflowOptions = $request->get('workflow', []);
-        $workflow = $workflowRegistry->get($this->element, $request->get('workflowName'));
+        $workflowOptions = $request->request->get('workflow', []);
+        $workflow = $workflowRegistry->get($this->element, $request->request->get('workflowName'));
 
-        if ($workflow->can($this->element, $request->get('transition'))) {
+        if ($workflow->can($this->element, $request->request->get('transition'))) {
             try {
-                $workflowManager->applyWithAdditionalData($workflow, $this->element, $request->get('transition'), $workflowOptions, true);
+                $workflowManager->applyWithAdditionalData($workflow, $this->element, $request->request->get('transition'), $workflowOptions, true);
 
                 $data = [
                     'success' => true,
@@ -115,7 +115,7 @@ class WorkflowController extends AdminAbstractController implements KernelContro
             } catch (ValidationException $e) {
                 $reason = '';
                 if (count($e->getSubItems()) > 0) {
-                    $reason = '<ul>' . implode('', array_map(fn ($item) => '<li>' . $item . '</li>', $e->getSubItems())) . '</ul>';
+                    $reason = '<ul>' . implode('', array_map(static fn ($item) => '<li>' . $item . '</li>', $e->getSubItems())) . '</ul>';
                 }
 
                 $data = [
@@ -132,9 +132,9 @@ class WorkflowController extends AdminAbstractController implements KernelContro
                 ];
             }
         } else {
-            $blockTransitionList = $workflow->buildTransitionBlockerList($this->element, $request->get('transition'));
+            $blockTransitionList = $workflow->buildTransitionBlockerList($this->element, $request->request->get('transition'));
 
-            $reasons = array_map(fn ($blockTransitionItem) => $blockTransitionItem->getMessage(), iterator_to_array($blockTransitionList->getIterator(), true));
+            $reasons = array_map(static fn ($blockTransitionItem) => $blockTransitionItem->getMessage(), iterator_to_array($blockTransitionList->getIterator(), true));
 
             $data = [
                 'success' => false,
@@ -152,19 +152,19 @@ class WorkflowController extends AdminAbstractController implements KernelContro
         Registry $workflowRegistry,
         Manager $workflowManager
     ): JsonResponse {
-        $workflowOptions = $request->get('workflow', []);
-        $workflow = $workflowRegistry->get($this->element, $request->get('workflowName'));
+        $workflowOptions = $request->request->get('workflow', []);
+        $workflow = $workflowRegistry->get($this->element, $request->request->get('workflowName'));
 
         $globalAction = $workflowManager->getGlobalAction(
-            $request->get('workflowName'),
-            $request->get('transition')
+            $request->request->get('workflowName'),
+            $request->request->get('transition')
         );
         $saveSubject = !$globalAction || $globalAction->getSaveSubject();
 
         try {
             $workflowManager->applyGlobalAction(
                 $workflow,
-                $this->element, $request->get('transition'),
+                $this->element, $request->request->get('transition'),
                 $workflowOptions, $saveSubject
             );
 
@@ -175,7 +175,7 @@ class WorkflowController extends AdminAbstractController implements KernelContro
         } catch (ValidationException $e) {
             $reason = '';
             if (count($e->getSubItems()) > 0) {
-                $reason = '<ul>' . implode('', array_map(fn ($item) => '<li>' . $item . '</li>', $e->getSubItems())) . '</ul>';
+                $reason = '<ul>' . implode('', array_map(static fn ($item) => '<li>' . $item . '</li>', $e->getSubItems())) . '</ul>';
             }
 
             $data = [
@@ -220,8 +220,8 @@ class WorkflowController extends AdminAbstractController implements KernelContro
             $url = $router->generate(
                 'opendxp_admin_workflow_show_graph',
                 [
-                    'cid' => $request->get('cid'),
-                    'ctype' => $request->get('ctype'),
+                    'cid' => $request->query->get('cid'),
+                    'ctype' => $request->query->get('ctype'),
                     'workflow' => $workflow->getName(),
                 ]
             );
@@ -250,10 +250,10 @@ class WorkflowController extends AdminAbstractController implements KernelContro
      *
      * @throws Exception
      */
-    #[Route('/show-graph', name: 'opendxp_admin_workflow_show_graph')]
+    #[Route('/show-graph', name: 'opendxp_admin_workflow_show_graph', methods: ['GET'])]
     public function showGraph(Request $request, Manager $workflowManager): Response
     {
-        $workflow = $workflowManager->getWorkflowByName($request->get('workflow'));
+        $workflow = $workflowManager->getWorkflowByName($request->query->get('workflow'));
 
         $response = new Response($this->getWorkflowSvg($workflow));
         $response->headers->set('Content-Type', 'image/svg+xml');
@@ -269,18 +269,18 @@ class WorkflowController extends AdminAbstractController implements KernelContro
     #[Route('/modal-custom-html', name: 'opendxp_admin_workflow_modal_custom_html', methods: ['POST'])]
     public function getModalCustomHtml(Request $request, Registry $workflowRegistry, Manager $manager): JsonResponse
     {
-        $workflow = $workflowRegistry->get($this->element, $request->get('workflowName'));
+        $workflow = $workflowRegistry->get($this->element, $request->request->get('workflowName'));
 
-        if ($request->get('isGlobalAction') == 'true') {
-            $globalAction = $manager->getGlobalAction($workflow->getName(), $request->get('transition'));
+        if ($request->request->get('isGlobalAction') === 'true') {
+            $globalAction = $manager->getGlobalAction($workflow->getName(), $request->request->get('transition'));
             if ($globalAction) {
                 return $this->customHtmlResponse($globalAction->getCustomHtmlService());
             }
-        } elseif ($workflow->can($this->element, $request->get('transition'))) {
+        } elseif ($workflow->can($this->element, $request->request->get('transition'))) {
             $enabledTransitions = $workflow->getEnabledTransitions($this->element);
             $transition = null;
             foreach ($enabledTransitions as $_transition) {
-                if ($_transition->getName() === $request->get('transition')) {
+                if ($_transition->getName() === $request->request->get('transition')) {
                     $transition = $_transition;
                 }
             }
@@ -400,16 +400,16 @@ class WorkflowController extends AdminAbstractController implements KernelContro
 
         $request = $event->getRequest();
 
-        if ($request->get('ctype') === 'document') {
-            $this->element = Document::getById((int) $request->get('cid', 0));
-        } elseif ($request->get('ctype') === 'asset') {
-            $this->element = Asset::getById((int) $request->get('cid', 0));
-        } elseif ($request->get('ctype') === 'object') {
-            $this->element = ConcreteObject::getById((int) $request->get('cid', 0));
+        if ($request->query->get('ctype') === 'document') {
+            $this->element = Document::getById((int) $request->query->get('cid', 0));
+        } elseif ($request->query->get('ctype') === 'asset') {
+            $this->element = Asset::getById((int) $request->query->get('cid', 0));
+        } elseif ($request->query->get('ctype') === 'object') {
+            $this->element = ConcreteObject::getById((int) $request->query->get('cid', 0));
         }
 
         if (!$this->element) {
-            throw new Exception('Cannot load element' . $request->get('cid') . ' of type \'' . $request->get('ctype') . '\'');
+            throw new Exception('Cannot load element' . $request->query->get('cid') . ' of type \'' . $request->query->get('ctype') . '\'');
         }
 
         //get the latest available version of the element -

--- a/src/Controller/Admin/WorkflowController.php
+++ b/src/Controller/Admin/WorkflowController.php
@@ -401,11 +401,11 @@ class WorkflowController extends AdminAbstractController implements KernelContro
         $request = $event->getRequest();
 
         if ($request->query->get('ctype') === 'document') {
-            $this->element = Document::getById((int) $request->query->get('cid', 0));
+            $this->element = Document::getById((int) $request->query->get('cid', '0'));
         } elseif ($request->query->get('ctype') === 'asset') {
-            $this->element = Asset::getById((int) $request->query->get('cid', 0));
+            $this->element = Asset::getById((int) $request->query->get('cid', '0'));
         } elseif ($request->query->get('ctype') === 'object') {
-            $this->element = ConcreteObject::getById((int) $request->query->get('cid', 0));
+            $this->element = ConcreteObject::getById((int) $request->query->get('cid', '0'));
         }
 
         if (!$this->element) {

--- a/src/Controller/Admin/WorkflowController.php
+++ b/src/Controller/Admin/WorkflowController.php
@@ -101,7 +101,7 @@ class WorkflowController extends AdminAbstractController implements KernelContro
     #[Route('/submit-workflow-transition', name: 'opendxp_admin_workflow_submitworkflowtransition', methods: ['POST'])]
     public function submitWorkflowTransitionAction(Request $request, Registry $workflowRegistry, Manager $workflowManager): JsonResponse
     {
-        $workflowOptions = $request->request->get('workflow', []);
+        $workflowOptions = $request->request->all('workflow');
         $workflow = $workflowRegistry->get($this->element, $request->request->get('workflowName'));
 
         if ($workflow->can($this->element, $request->request->get('transition'))) {
@@ -152,7 +152,7 @@ class WorkflowController extends AdminAbstractController implements KernelContro
         Registry $workflowRegistry,
         Manager $workflowManager
     ): JsonResponse {
-        $workflowOptions = $request->request->get('workflow', []);
+        $workflowOptions = $request->request->all('workflow');
         $workflow = $workflowRegistry->get($this->element, $request->request->get('workflowName'));
 
         $globalAction = $workflowManager->getGlobalAction(

--- a/src/Controller/GDPR/AssetController.php
+++ b/src/Controller/GDPR/AssetController.php
@@ -28,10 +28,6 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * Class AssetController
- *
- * @package GDPRDataExtractorBundle\Controller
- *
  * @internal
  */
 #[Route('/asset')]
@@ -49,7 +45,7 @@ class AssetController extends AdminAbstractController implements KernelControlle
     #[Route('/search-assets', name: 'opendxp_admin_gdpr_asset_searchasset', methods: ['GET'])]
     public function searchAssetAction(Request $request, Assets $service): JsonResponse
     {
-        $allParams = [...$request->request->all(), ...$request->query->all()];
+        $allParams = $request->query->all();
 
         $result = $service->searchData(
             (int)$allParams['id'],
@@ -70,7 +66,7 @@ class AssetController extends AdminAbstractController implements KernelControlle
     #[Route('/export', name: 'opendxp_admin_gdpr_asset_exportassets', methods: ['GET'])]
     public function exportAssetsAction(Request $request, Assets $service): Response
     {
-        $asset = Asset::getById((int) $request->get('id'));
+        $asset = Asset::getById((int) $request->query->get('id'));
         if (!$asset) {
             throw $this->createNotFoundException('Asset not found');
         }

--- a/src/Controller/GDPR/DataObjectController.php
+++ b/src/Controller/GDPR/DataObjectController.php
@@ -27,8 +27,6 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * Class DataObjectController
- *
  * @internal
  */
 #[Route('/data-object')]
@@ -46,7 +44,7 @@ class DataObjectController extends AdminAbstractController implements KernelCont
     #[Route('/search-data-objects', name: 'opendxp_admin_gdpr_dataobject_searchdataobjects', methods: ['GET'])]
     public function searchDataObjectsAction(Request $request, DataObjects $service): JsonResponse
     {
-        $allParams = [...$request->request->all(), ...$request->query->all()];
+        $allParams = $request->query->all();
 
         $result = $service->searchData(
             (int)$allParams['id'],
@@ -67,10 +65,12 @@ class DataObjectController extends AdminAbstractController implements KernelCont
     #[Route('/export', name: 'opendxp_admin_gdpr_dataobject_exportdataobject', methods: ['GET'])]
     public function exportDataObjectAction(Request $request, DataObjects $service): JsonResponse
     {
-        $object = DataObject::getById((int) $request->get('id'));
+        $object = DataObject::getById((int) $request->query->get('id'));
+
         if (!$object) {
             throw $this->createNotFoundException('Object not found');
         }
+
         if (!$object->isAllowed('view')) {
             throw $this->createAccessDeniedException('Export denied');
         }

--- a/src/Controller/GDPR/OpenDxpUsersController.php
+++ b/src/Controller/GDPR/OpenDxpUsersController.php
@@ -44,7 +44,7 @@ class OpenDxpUsersController extends AdminAbstractController implements KernelCo
     #[Route('/search-users', name: 'opendxp_admin_gdpr_opendxpusers_searchusers', methods: ['GET'])]
     public function searchUsersAction(Request $request, OpenDxpUsers $openDxpUsers): JsonResponse
     {
-        $allParams = [...$request->request->all(), ...$request->query->all()];
+        $allParams = $request->query->all();
 
         $result = $openDxpUsers->searchData(
             (int)$allParams['id'],
@@ -63,7 +63,7 @@ class OpenDxpUsersController extends AdminAbstractController implements KernelCo
     public function exportUserDataAction(Request $request, OpenDxpUsers $openDxpUsers): JsonResponse
     {
         $this->checkPermission('users');
-        $userData = $openDxpUsers->getExportData((int)$request->get('id'));
+        $userData = $openDxpUsers->getExportData((int)$request->query->get('id'));
 
         $json = $this->encodeJson($userData, [], JsonResponse::DEFAULT_ENCODING_OPTIONS | JSON_PRETTY_PRINT);
 

--- a/src/Controller/GDPR/SentMailController.php
+++ b/src/Controller/GDPR/SentMailController.php
@@ -25,8 +25,6 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * Class SentMailController
- *
  * @internal
  */
 #[Route('/sent-mail')]
@@ -46,7 +44,7 @@ class SentMailController extends AdminAbstractController implements KernelContro
     {
         $this->checkPermission('emails');
 
-        $sentMail = Log::getById((int) $request->get('id'));
+        $sentMail = Log::getById((int) $request->query->get('id'));
         if (!$sentMail) {
             throw $this->createNotFoundException();
         }

--- a/src/Controller/Traits/ApplySchedulerDataTrait.php
+++ b/src/Controller/Traits/ApplySchedulerDataTrait.php
@@ -30,9 +30,9 @@ trait ApplySchedulerDataTrait
     protected function applySchedulerDataToElement(Request $request, ElementInterface $element, UserProxy|User|null $adminUser): void
     {
         // scheduled tasks
-        if ($request->get('scheduler')) {
+        if ($request->request->has('scheduler')) {
             $tasks = [];
-            $tasksData = $this->decodeJson($request->get('scheduler'));
+            $tasksData = $this->decodeJson($request->request->get('scheduler'));
 
             if (!empty($tasksData)) {
                 foreach ($tasksData as $taskData) {

--- a/src/EventListener/UserPerspectiveListener.php
+++ b/src/EventListener/UserPerspectiveListener.php
@@ -66,7 +66,7 @@ class UserPerspectiveListener implements EventSubscriberInterface, LoggerAwareIn
     protected function setRequestedPerspective(User $user, Request $request): void
     {
         // update perspective settings
-        $requestedPerspective = $request->get('perspective');
+        $requestedPerspective = $request->query->get('perspective');
 
         if ($requestedPerspective && $requestedPerspective !== $user->getActivePerspective()) {
             $existingPerspectives = array_keys(\OpenDxp\Bundle\AdminBundle\Perspective\Config::get());

--- a/src/GDPR/DataProvider/OpenDxpUsers.php
+++ b/src/GDPR/DataProvider/OpenDxpUsers.php
@@ -93,11 +93,11 @@ class OpenDxpUsers implements DataProviderInterface
         foreach ($userListing->getUsers() as $user) {
             $users[] = [
                 'id' => $user->getId(),
-                'username' => $user->getUsername(),
+                'name' => $user->getName(),
                 'firstname' => $user->getFirstname(),
                 'lastname' => $user->getLastname(),
                 'email' => $user->getEmail(),
-                '__gdprIsDeletable' => $user->getId() != $currentUser->getId(),
+                '__gdprIsDeletable' => $user->getId() !== $currentUser->getId(),
 
             ];
         }

--- a/src/Security/Authenticator/AdminAbstractAuthenticator.php
+++ b/src/Security/Authenticator/AdminAbstractAuthenticator.php
@@ -47,9 +47,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 abstract class AdminAbstractAuthenticator extends AbstractAuthenticator implements LoggerAwareInterface
 {
-    public const OPENDXP_ADMIN_LOGIN = 'opendxp_admin_login';
-
-    public const OPENDXP_ADMIN_LOGIN_CHECK = 'opendxp_admin_login_check';
+    public const string OPENDXP_ADMIN_LOGIN = 'opendxp_admin_login';
+    public const string OPENDXP_ADMIN_LOGIN_CHECK = 'opendxp_admin_login_check';
 
     use LoggerAwareTrait;
 
@@ -99,20 +98,25 @@ abstract class AdminAbstractAuthenticator extends AbstractAuthenticator implemen
 
         // as we authenticate statelessly (short lived sessions) the authentication is called for
         // every request. therefore we only redirect if we're on the login page
-        if (!in_array($request->attributes->get('_route'), [
-            self::OPENDXP_ADMIN_LOGIN,
-            self::OPENDXP_ADMIN_LOGIN_CHECK,
-        ])) {
+        if (!in_array(
+            $request->attributes->get('_route'),
+            [
+                self::OPENDXP_ADMIN_LOGIN,
+                self::OPENDXP_ADMIN_LOGIN_CHECK,
+            ],
+            true
+        )
+        ) {
             return null;
         }
 
-        if ($request->get('deeplink') && $request->get('deeplink') !== 'true') {
+        if ($request->query->has('deeplink') && $request->query->get('deeplink') !== 'true') {
             $url = $this->router->generate('opendxp_admin_login_deeplink');
-            $url .= '?' . $request->get('deeplink');
+            $url .= '?' . $request->query->get('deeplink');
         } else {
             $url = $this->router->generate('opendxp_admin_index', [
                 '_dc' => time(),
-                'perspective' => strip_tags($request->get('perspective', '')),
+                'perspective' => strip_tags($request->query->get('perspective', '')),
             ]);
         }
 
@@ -131,7 +135,7 @@ abstract class AdminAbstractAuthenticator extends AbstractAuthenticator implemen
         if (Authentication::isValidUser($user->getUser())) {
             $openDxpUser = $user->getUser();
 
-            Session::useBag($session, function (AttributeBagInterface $adminSession, SessionInterface $session) use ($openDxpUser): void {
+            Session::useBag($session, static function (AttributeBagInterface $adminSession, SessionInterface $session) use ($openDxpUser): void {
                 $session->migrate();
                 $adminSession->set('user', $openDxpUser);
             });

--- a/src/Security/Authenticator/AdminTokenAuthenticator.php
+++ b/src/Security/Authenticator/AdminTokenAuthenticator.php
@@ -33,24 +33,25 @@ class AdminTokenAuthenticator extends AdminAbstractAuthenticator
 {
     public function supports(Request $request): ?bool
     {
-        return $request->attributes->get('_route') === self::OPENDXP_ADMIN_LOGIN_CHECK
-            && $request->get('token');
+        return
+            $request->attributes->get('_route') === self::OPENDXP_ADMIN_LOGIN_CHECK &&
+            $request->query->has('token');
     }
 
     public function authenticate(Request $request): Passport
     {
-        $openDxpUser = Authentication::authenticateToken($request->get('token'));
+        $openDxpUser = Authentication::authenticateToken($request->query->get('token'));
 
         if ($openDxpUser) {
             $openDxpUser->setTwoFactorAuthentication('required', false);
 
             $userBadge = new UserBadge($openDxpUser->getUsername(), fn () => new User($openDxpUser));
 
-            if ($request->get('reset', false)) {
+            if ($request->query->get('reset', false)) {
                 // save the information to session when the user want's to reset the password
                 // this is because otherwise the old password is required
 
-                Session::useBag($request->getSession(), function (AttributeBagInterface $adminSession): void {
+                Session::useBag($request->getSession(), static function (AttributeBagInterface $adminSession): void {
                     $adminSession->set('password_reset', true);
                 });
             }

--- a/src/Security/Authenticator/AdminTokenAuthenticator.php
+++ b/src/Security/Authenticator/AdminTokenAuthenticator.php
@@ -47,7 +47,7 @@ class AdminTokenAuthenticator extends AdminAbstractAuthenticator
 
             $userBadge = new UserBadge($openDxpUser->getUsername(), fn () => new User($openDxpUser));
 
-            if ($request->query->get('reset', false)) {
+            if ($request->query->get('reset')) {
                 // save the information to session when the user want's to reset the password
                 // this is because otherwise the old password is required
 

--- a/src/Security/CsrfProtectionHandler.php
+++ b/src/Security/CsrfProtectionHandler.php
@@ -43,8 +43,11 @@ class CsrfProtectionHandler implements LoggerAwareInterface
     {
         $csrfToken = $this->getCsrfToken($request->getSession());
         $requestCsrfToken = $request->headers->get('x_opendxp_csrf_token');
+
         if (!$requestCsrfToken) {
-            $requestCsrfToken = $request->get('csrfToken');
+            $requestCsrfToken = $request->query->has('csrfToken')
+                ? $request->query->get('csrfToken')
+                : $request->request->get('csrfToken');
         }
 
         if (!$csrfToken || $csrfToken !== $requestCsrfToken) {


### PR DESCRIPTION
Monster Task: Replace `$request->get()` with `$request->query->get()` or `$request->request->get()` for clarity and strictness. `$request->get()`  is also deprecated since symfony 7.4

Also:
- Replace `$_FILES` with `$request->files()`
- Remove orphaned  symfony caches clear feature to allow multiple envs (which already has been removed in public)