### PR TITLE
Refactor SQL queries: enforce parameterized bindings and consistent style

### DIFF
--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\AdminBundle\Controller\Admin\Asset;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Exception;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\UnableToReadFile;
@@ -96,13 +98,14 @@ class AssetHelperController extends AdminAbstractController
         $userIds = [$user->getId()];
         // collect all roles
         $userIds = [...$userIds, ...$user->getRoles()];
-        $userIds = implode(',', $userIds);
 
-        $query = 'select distinct c1.id from gridconfigs c1, gridconfig_shares s
-                    where (c1.searchType = ' . $db->quote($searchType) . ' and ((c1.id = s.gridConfigId and s.sharedWithUserId IN (' . $userIds . '))) and c1.classId = ' . $db->quote($classId) . ')
-                            UNION distinct select c2.id from gridconfigs c2 where shareGlobally = 1 and c2.classId = '. $db->quote($classId) . '  and c2.ownerId != ' . $db->quote($user->getId());
-
-        $ids = $db->fetchFirstColumn($query);
+        $ids = $db->fetchFirstColumn(
+            'SELECT DISTINCT c1.id FROM gridconfigs c1, gridconfig_shares s
+                WHERE (c1.searchType = ? AND c1.id = s.gridConfigId AND s.sharedWithUserId IN (?) AND c1.classId = ?)
+            UNION DISTINCT SELECT c2.id FROM gridconfigs c2 WHERE shareGlobally = 1 AND c2.classId = ? AND c2.ownerId != ?',
+            [$searchType, $userIds, $classId, $classId, $user->getId()],
+            [ParameterType::STRING, ArrayParameterType::INTEGER, ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER]
+        );
 
         if ($ids) {
             $ids = implode(',', $ids);
@@ -207,8 +210,11 @@ class AssetHelperController extends AdminAbstractController
                 try {
                     $userIds = [$this->getAdminUser()->getId()];
                     $userIds = [...$userIds, ...$this->getAdminUser()->getRoles()];
-                    $userIds = implode(',', $userIds);
-                    $shared = ($savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally()) || $db->fetchOne('select * from gridconfig_shares where sharedWithUserId IN (' . $userIds . ') and gridConfigId = ' . $savedGridConfig->getId());
+                    $shared = ($savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally()) || $db->fetchOne(
+                        'SELECT * FROM gridconfig_shares WHERE sharedWithUserId IN (?) AND gridConfigId = ?',
+                        [$userIds, $savedGridConfig->getId()],
+                        [ArrayParameterType::INTEGER, ParameterType::INTEGER]
+                    );
                 } catch (Exception) {
                     // fail silently?
                 }
@@ -432,8 +438,11 @@ class AssetHelperController extends AdminAbstractController
         ];
 
         $db = Db::get();
-        $allShares = $db->fetchAllAssociative('select s.sharedWithUserId, u.type from gridconfig_shares s, users u
-                      where s.sharedWithUserId = u.id and s.gridConfigId = ' . $gridConfigId);
+        $allShares = $db->fetchAllAssociative(
+            'SELECT s.sharedWithUserId, u.type FROM gridconfig_shares s, users u
+                WHERE s.sharedWithUserId = u.id AND s.gridConfigId = ?',
+            [$gridConfigId]
+        );
 
         foreach ($allShares as $share) {
             $type = $share['type'];

--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -205,30 +205,39 @@ class AssetHelperController extends AdminAbstractController
             $savedGridConfig = GridConfig::getById((int) $requestedGridConfigId);
 
             if ($savedGridConfig) {
-                $shared = null;
-
-                try {
+                $shared = false;
+                if (!$this->getAdminUser()->isAdmin()) {
                     $userIds = [$this->getAdminUser()->getId()];
                     $userIds = [...$userIds, ...$this->getAdminUser()->getRoles()];
-                    $shared = ($savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally()) || $db->fetchOne(
-                        'SELECT * FROM gridconfig_shares WHERE sharedWithUserId IN (?) AND gridConfigId = ?',
+                    $isSharedGlobally = $savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally();
+
+                    $isSharedWithUser = (bool) $db->fetchOne(
+                        'SELECT 1 FROM gridconfig_shares WHERE sharedWithUserId IN (?) AND gridConfigId = ?',
                         [$userIds, $savedGridConfig->getId()],
                         [ArrayParameterType::INTEGER, ParameterType::INTEGER]
                     );
-                } catch (Exception) {
-                    // fail silently?
+
+                    $shared = $isSharedGlobally || $isSharedWithUser;
+
+                    if (!$shared && $savedGridConfig->getOwnerId() !== $this->getAdminUser()->getId()) {
+                        throw new Exception('You are neither the owner of this config nor it is shared with you');
+                    }
                 }
 
-                if (!$shared && $savedGridConfig->getOwnerId() !== $this->getAdminUser()->getId()) {
-                    throw new Exception('You are neither the owner of this config nor it is shared with you');
-                }
                 $gridConfigId = $savedGridConfig->getId();
                 $gridConfig = $savedGridConfig->getConfig();
                 $gridConfig = json_decode($gridConfig, true);
-                $gridConfigName = $savedGridConfig->getName();
-                $gridConfigDescription = $savedGridConfig->getDescription();
+                $gridConfigName = SecurityHelper::convertHtmlSpecialChars($savedGridConfig->getName());
+                $gridConfigDescription = SecurityHelper::convertHtmlSpecialChars($savedGridConfig->getDescription());
                 $sharedGlobally = $savedGridConfig->isShareGlobally();
                 $setAsFavourite = $savedGridConfig->isSetAsFavourite();
+
+                foreach ($gridConfig['columns'] as &$column) {
+                    if (array_key_exists('isOperator', $column) && $column['isOperator']) {
+                        $colAttributes = &$column['fieldConfig']['attributes'];
+                        SecurityHelper::convertHtmlSpecialCharsArrayKeys($colAttributes, ['label', 'attribute', 'param1']);
+                    }
+                }
             }
         }
 

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1838,9 +1838,9 @@ class ClassController extends AdminAbstractController implements KernelControlle
     public function suggestClassIdentifierAction(): Response
     {
         $db = Db::get();
-        $maxId = $db->fetchOne('SELECT MAX(CAST(id AS SIGNED)) FROM classes;');
+        $maxId = $db->fetchOne('SELECT MAX(CAST(id AS SIGNED)) FROM classes');
 
-        $existingIds = $db->fetchFirstColumn('select LOWER(id) from classes');
+        $existingIds = $db->fetchFirstColumn('SELECT LOWER(id) FROM classes');
 
         $result = [
             'suggestedIdentifier' => $maxId ? $maxId + 1 : 1,

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\AdminBundle\Controller\Admin\DataObject;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Exception;
 use OpenDxp\Bundle\AdminBundle\Controller\AdminAbstractController;
 use OpenDxp\Controller\KernelControllerEventInterface;
@@ -218,8 +219,11 @@ class ClassificationstoreController extends AdminAbstractController implements K
 
             if ($allowedGroupIds) {
                 $db = \OpenDxp\Db::get();
-                $query = 'select * from classificationstore_collectionrelations where groupId in (' . implode(',', $allowedGroupIds) .')';
-                $relationList = $db->fetchAllAssociative($query);
+                $relationList = $db->fetchAllAssociative(
+                    'SELECT * FROM classificationstore_collectionrelations WHERE groupId IN (?)',
+                    [$allowedGroupIds],
+                    [ArrayParameterType::INTEGER]
+                );
 
                 foreach ($relationList as $item) {
                     $allowedCollectionIds[] = $item['colId'];
@@ -902,9 +906,12 @@ class ClassificationstoreController extends AdminAbstractController implements K
         if ($ids) {
             $db = \OpenDxp\Db::get();
             $mappedData = [];
-            $groupsData = $db->fetchAllAssociative('select * from classificationstore_groups g, classificationstore_collectionrelations c where colId IN (:ids) and g.id = c.groupId', [
-                'ids' => implode(',', array_filter($ids, is_numeric(...))),
-            ]);
+            $groupsData = $db->fetchAllAssociative(
+                'SELECT * FROM classificationstore_groups g, classificationstore_collectionrelations c
+                    WHERE colId IN (?) AND g.id = c.groupId',
+                [array_values(array_filter($ids, is_numeric(...)))],
+                [ArrayParameterType::INTEGER]
+            );
 
             foreach ($groupsData as $groupData) {
                 $mappedData[$groupData['id']] = $groupData;
@@ -1434,7 +1441,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
                   ) all_rows) item where id = ' .  $id . ';';
         }
 
-        $db->executeQuery('select @rownum := 0;');
+        $db->executeStatement('SET @rownum = 0');
         $result = $db->fetchAllAssociative($query);
 
         $page = (int) $result[0]['page'] ;

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1204,8 +1204,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             $db = Db::get();
             $children = $db->fetchAllAssociative(
-                'SELECT id, modificationDate, versionCount FROM objects'
-                .' WHERE parentId = ? ORDER BY `index` ASC',
+                'SELECT id, modificationDate, versionCount FROM objects WHERE parentId = ? ORDER BY `index` ASC',
                 [$parentObject->getId()]
             );
             $index = 0;
@@ -1279,8 +1278,8 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             );
 
             $siblings = $db->fetchAllAssociative(
-                'SELECT id, modificationDate, versionCount, `key`, `index` FROM objects'
-                ." WHERE parentId = ? AND id != ? AND `type` IN ('object', 'variant','folder') ORDER BY `index` ASC",
+                'SELECT id, modificationDate, versionCount, `key`, `index` FROM objects
+                    WHERE parentId = ? AND id != ? AND `type` IN ("object", "variant", "folder") ORDER BY `index` ASC',
                 [$updatedObject->getParentId(), $updatedObject->getId()]
             );
             $index = 0;

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -310,12 +310,15 @@ class DataObjectHelperController extends AdminAbstractController
                 if (!$this->getAdminUser()->isAdmin()) {
                     $userIds = [$this->getAdminUser()->getId()];
                     $userIds = [...$userIds, ...$this->getAdminUser()->getRoles()];
-                    $shared = ($savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally()) || $db->fetchOne(
+                    $isSharedGlobally = $savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally();
+
+                    $isSharedWithUser = (bool) $db->fetchOne(
                         'SELECT 1 FROM gridconfig_shares WHERE sharedWithUserId IN (?) AND gridConfigId = ?',
                         [$userIds, $savedGridConfig->getId()],
                         [ArrayParameterType::INTEGER, ParameterType::INTEGER]
                     );
-                    //                  $shared = $savedGridConfig->isShareGlobally() || GridConfigShare::getByGridConfigAndSharedWithId($savedGridConfig->getId(), $this->getUser()->getId());
+
+                    $shared = $isSharedGlobally || $isSharedWithUser;
 
                     if (!$shared && $savedGridConfig->getOwnerId() !== $this->getAdminUser()->getId()) {
                         throw new Exception('You are neither the owner of this config nor it is shared with you');
@@ -387,7 +390,6 @@ class DataObjectHelperController extends AdminAbstractController
                         if (str_starts_with($key, '~')) {
                             // not needed for now
                             $type = $keyParts[1];
-                            //                            $field = $keyParts[2];
                             $groupAndKeyId = explode('-', $keyParts[3]);
                             $keyId = (int) $groupAndKeyId[1];
 

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\AdminBundle\Controller\Admin\DataObject;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Exception;
 use InvalidArgumentException;
 use League\Flysystem\FilesystemException;
@@ -109,14 +111,15 @@ class DataObjectHelperController extends AdminAbstractController
         $userIds = [$user->getId()];
         // collect all roles
         $userIds = [...$userIds, ...$user->getRoles()];
-        $userIds = implode(',', $userIds);
         $db = Db::get();
 
-        $query = 'select distinct c1.id from gridconfigs c1, gridconfig_shares s
-                    where (c1.searchType = ' . $db->quote($searchType) . ' and ((c1.id = s.gridConfigId and s.sharedWithUserId IN (' . $userIds . '))) and c1.classId = ' . $db->quote($classId) . ')
-                            UNION distinct select c2.id from gridconfigs c2 where shareGlobally = 1 and c2.classId = '. $db->quote($classId) . '  and c2.ownerId != ' . $db->quote($user->getId());
-
-        $ids = $db->fetchFirstColumn($query);
+        $ids = $db->fetchFirstColumn(
+            'SELECT DISTINCT c1.id FROM gridconfigs c1, gridconfig_shares s
+                WHERE (c1.searchType = ? AND c1.id = s.gridConfigId AND s.sharedWithUserId IN (?) AND c1.classId = ?)
+            UNION DISTINCT SELECT c2.id FROM gridconfigs c2 WHERE shareGlobally = 1 AND c2.classId = ? AND c2.ownerId != ?',
+            [$searchType, $userIds, $classId, $classId, $user->getId()],
+            [ParameterType::STRING, ArrayParameterType::INTEGER, ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER]
+        );
 
         if ($ids) {
             $ids = implode(',', $ids);
@@ -307,8 +310,11 @@ class DataObjectHelperController extends AdminAbstractController
                 if (!$this->getAdminUser()->isAdmin()) {
                     $userIds = [$this->getAdminUser()->getId()];
                     $userIds = [...$userIds, ...$this->getAdminUser()->getRoles()];
-                    $userIds = implode(',', $userIds);
-                    $shared = ($savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally()) || $db->fetchOne('select 1 from gridconfig_shares where sharedWithUserId IN ('.$userIds.') and gridConfigId = '.$savedGridConfig->getId());
+                    $shared = ($savedGridConfig->getOwnerId() !== $userId && $savedGridConfig->isShareGlobally()) || $db->fetchOne(
+                        'SELECT 1 FROM gridconfig_shares WHERE sharedWithUserId IN (?) AND gridConfigId = ?',
+                        [$userIds, $savedGridConfig->getId()],
+                        [ArrayParameterType::INTEGER, ParameterType::INTEGER]
+                    );
                     //                  $shared = $savedGridConfig->isShareGlobally() || GridConfigShare::getByGridConfigAndSharedWithId($savedGridConfig->getId(), $this->getUser()->getId());
 
                     if (!$shared && $savedGridConfig->getOwnerId() !== $this->getAdminUser()->getId()) {
@@ -716,11 +722,10 @@ class DataObjectHelperController extends AdminAbstractController
             $searchType = $request->request->get('searchType');
             $user = $this->getAdminUser();
             $db = Db::get();
-            $db->executeQuery('delete from gridconfig_favourites where '
-                . 'ownerId = ' . $user->getId()
-                . ' and classId = ' . $db->quote($classId) .
-                ' and searchType = ' . $db->quote($searchType)
-                . ' and objectId != ' . $objectId . ' and objectId != 0');
+            $db->executeStatement(
+                'DELETE FROM gridconfig_favourites WHERE ownerId = ? AND classId = ? AND searchType = ? AND objectId != ? AND objectId != 0',
+                [$user->getId(), $classId, $searchType, $objectId]
+            );
 
             return $this->adminJson(['success' => true]);
         }
@@ -766,12 +771,10 @@ class DataObjectHelperController extends AdminAbstractController
                     $favourite->save();
                 }
                 $db = Db::get();
-                $count = $db->fetchOne('select * from gridconfig_favourites where '
-                    . 'ownerId = ' . $user->getId()
-                    . ' and classId = ' . $db->quote($classId).
-                    ' and searchType = ' . $db->quote($searchType)
-                    . ' and objectId != ' . $objectId . ' and objectId != 0'
-                    . ' and `type` != ' . $db->quote($type));
+                $count = $db->fetchOne(
+                    'SELECT * FROM gridconfig_favourites WHERE ownerId = ? AND classId = ? AND searchType = ? AND objectId != ? AND objectId != 0 AND `type` != ?',
+                    [$user->getId(), $classId, $searchType, $objectId, $type]
+                );
                 $specializedConfigs = $count > 0;
             } catch (Exception) {
                 $favourite->delete();
@@ -791,8 +794,11 @@ class DataObjectHelperController extends AdminAbstractController
         ];
 
         $db = Db::get();
-        $allShares = $db->fetchAllAssociative('select s.sharedWithUserId, u.type from gridconfig_shares s, users u
-                      where s.sharedWithUserId = u.id and s.gridConfigId = ' . $gridConfigId);
+        $allShares = $db->fetchAllAssociative(
+            'SELECT s.sharedWithUserId, u.type FROM gridconfig_shares s, users u
+                WHERE s.sharedWithUserId = u.id AND s.gridConfigId = ?',
+            [$gridConfigId]
+        );
 
         foreach ($allShares as $share) {
             $type = $share['type'];

--- a/src/Controller/Admin/PortalController.php
+++ b/src/Controller/Admin/PortalController.php
@@ -293,9 +293,18 @@ class PortalController extends AdminAbstractController implements KernelControll
             $end = $startDate - ($i * 86400);
             $start = $end - 86399;
 
-            $o = $db->fetchOne('SELECT COUNT(*) AS count FROM objects WHERE modificationDate > '.$start . ' AND modificationDate < '.$end);
-            $a = $db->fetchOne('SELECT COUNT(*) AS count FROM assets WHERE modificationDate > '.$start . ' AND modificationDate < '.$end);
-            $d = $db->fetchOne('SELECT COUNT(*) AS count FROM documents WHERE modificationDate > '.$start . ' AND modificationDate < '.$end);
+            $o = $db->fetchOne(
+                'SELECT COUNT(*) AS count FROM objects WHERE modificationDate > ? AND modificationDate < ?',
+                [$start, $end]
+            );
+            $a = $db->fetchOne(
+                'SELECT COUNT(*) AS count FROM assets WHERE modificationDate > ? AND modificationDate < ?',
+                [$start, $end]
+            );
+            $d = $db->fetchOne(
+                'SELECT COUNT(*) AS count FROM documents WHERE modificationDate > ? AND modificationDate < ?',
+                [$start, $end]
+            );
 
             $date = new DateTime();
             $date->setTimestamp($start);

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -565,7 +565,7 @@ class SettingsController extends AdminAbstractController
 
         // public files
         Tool\Storage::get('thumbnail')->deleteDirectory('/');
-        Db::get()->executeQuery('TRUNCATE TABLE assets_image_thumbnail_cache');
+        Db::get()->executeStatement('TRUNCATE TABLE assets_image_thumbnail_cache');
 
         Tool\Storage::get('asset_cache')->deleteDirectory('/');
 
@@ -1199,12 +1199,11 @@ class SettingsController extends AdminAbstractController
     protected function deleteViews(string $language, string $dbName): void
     {
         $db = \OpenDxp\Db::get();
-        $views = $db->fetchAllAssociative('SHOW FULL TABLES IN ' . $db->quoteIdentifier($dbName) . " WHERE TABLE_TYPE LIKE 'VIEW'");
+        $views = $db->fetchAllAssociative(sprintf('SHOW FULL TABLES IN %s WHERE TABLE_TYPE LIKE "VIEW"', $db->quoteIdentifier($dbName)));
 
         foreach ($views as $view) {
             if (preg_match('/^object_localized_[0-9]+_' . $language . '$/', $view['Tables_in_' . $dbName])) {
-                $sql = 'DROP VIEW ' . $db->quoteIdentifier($view['Tables_in_' . $dbName]);
-                $db->executeQuery($sql);
+                $db->executeStatement(sprintf('DROP VIEW %s', $db->quoteIdentifier($view['Tables_in_' . $dbName])));
             }
         }
     }

--- a/src/DataObject/GridColumnConfig/Operator/RequiredBy.php
+++ b/src/DataObject/GridColumnConfig/Operator/RequiredBy.php
@@ -59,12 +59,12 @@ final class RequiredBy extends AbstractOperator
         }
 
         if ($this->getOnlyCount()) {
-            $query = 'select count(*) from dependencies where targettype = ? AND targetid = ?'. $typeCondition;
+            $query = 'SELECT COUNT(*) FROM dependencies WHERE targettype = ? AND targetid = ?' . $typeCondition;
             $count = $db->fetchOne($query, [Service::getElementType($element), $element->getId()]);
             $result->value = $count;
         } else {
             $resultList = [];
-            $query = 'select * from dependencies where targettype = ? AND targetid = ?'. $typeCondition;
+            $query = 'SELECT * FROM dependencies WHERE targettype = ? AND targetid = ?' . $typeCondition;
             $dependencies = $db->fetchAllAssociative($query, [Service::getElementType($element), $element->getId()]);
             foreach ($dependencies as $dependency) {
                 $sourceType = $dependency['sourcetype'];

--- a/src/EventListener/GridConfigListener.php
+++ b/src/EventListener/GridConfigListener.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\AdminBundle\EventListener;
 
+use Doctrine\DBAL\ArrayParameterType;
 use OpenDxp\Db;
 use OpenDxp\Event\DataObjectClassDefinitionEvents;
 use OpenDxp\Event\DataObjectEvents;
@@ -54,9 +55,13 @@ class GridConfigListener implements EventSubscriberInterface
 
         // collect gridConfigs for that class id
         $db = Db::get();
-        $gridConfigIds = $db->fetchFirstColumn('select id from gridconfigs where classId = ?', [$classId]);
+        $gridConfigIds = $db->fetchFirstColumn('SELECT id FROM gridconfigs WHERE classId = ?', [$classId]);
         if ($gridConfigIds) {
-            $db->executeQuery('delete from gridconfig_shares where gridConfigId in (' . implode('', $gridConfigIds) . ')');
+            $db->executeStatement(
+                'DELETE FROM gridconfig_shares WHERE gridConfigId IN (?)',
+                [$gridConfigIds],
+                [ArrayParameterType::INTEGER]
+            );
         }
 
         $this->cleanupGridConfigs('classId = ' . $db->quote($classId));
@@ -70,9 +75,13 @@ class GridConfigListener implements EventSubscriberInterface
 
         $db = Db::get();
 
-        $gridConfigIds = $db->fetchFirstColumn('select id from gridconfigs where ownerId = ' . $userId);
+        $gridConfigIds = $db->fetchFirstColumn('SELECT id FROM gridconfigs WHERE ownerId = ?', [$userId]);
         if ($gridConfigIds) {
-            $db->executeQuery('delete from gridconfig_shares where gridConfigId in (' . implode('', $gridConfigIds) . ')');
+            $db->executeStatement(
+                'DELETE FROM gridconfig_shares WHERE gridConfigId IN (?)',
+                [$gridConfigIds],
+                [ArrayParameterType::INTEGER]
+            );
         }
 
         $this->cleanupGridConfigs('ownerId = ' . $userId);
@@ -82,12 +91,12 @@ class GridConfigListener implements EventSubscriberInterface
     protected function cleanupGridConfigs(string $condition): void
     {
         $db = Db::get();
-        $db->executeQuery('DELETE FROM gridconfigs where ' . $condition);
+        $db->executeStatement('DELETE FROM gridconfigs WHERE ' . $condition);
     }
 
     protected function cleanupGridConfigFavourites(string $condition): void
     {
         $db = Db::get();
-        $db->executeQuery('DELETE FROM gridconfig_favourites where ' . $condition);
+        $db->executeStatement('DELETE FROM gridconfig_favourites WHERE ' . $condition);
     }
 }

--- a/src/EventListener/ImportConfigListener.php
+++ b/src/EventListener/ImportConfigListener.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace OpenDxp\Bundle\AdminBundle\EventListener;
 
+use Doctrine\DBAL\ArrayParameterType;
 use OpenDxp\Db;
 use OpenDxp\Event\DataObjectClassDefinitionEvents;
 use OpenDxp\Event\Model\DataObject\ClassDefinitionEvent;
@@ -43,9 +44,13 @@ class ImportConfigListener implements EventSubscriberInterface
 
         // collect gridConfigs for that class id
         $db = Db::get();
-        $importConfigIds = $db->fetchFirstColumn('select id from importconfigs where classId = ?', [$classId]);
+        $importConfigIds = $db->fetchFirstColumn('SELECT id FROM importconfigs WHERE classId = ?', [$classId]);
         if ($importConfigIds) {
-            $db->executeQuery('delete from importconfig_shares where importConfigId in (' . implode('', $importConfigIds) . ')');
+            $db->executeStatement(
+                'DELETE FROM importconfig_shares WHERE importConfigId IN (?)',
+                [$importConfigIds],
+                [ArrayParameterType::INTEGER]
+            );
         }
 
         $this->cleanupImportConfigs('classId = ' . $db->quote($classId));
@@ -58,9 +63,13 @@ class ImportConfigListener implements EventSubscriberInterface
 
         $db = Db::get();
 
-        $importConfigIds = $db->fetchFirstColumn('select id from importconfigs where ownerId = ?', [$userId]);
+        $importConfigIds = $db->fetchFirstColumn('SELECT id FROM importconfigs WHERE ownerId = ?', [$userId]);
         if ($importConfigIds) {
-            $db->executeQuery('delete from importconfig_shares where importConfigId in (' . implode('', $importConfigIds) . ')');
+            $db->executeStatement(
+                'DELETE FROM importconfig_shares WHERE importConfigId IN (?)',
+                [$importConfigIds],
+                [ArrayParameterType::INTEGER]
+            );
         }
 
         $this->cleanupImportConfigs('ownerId = ' . $userId);
@@ -69,6 +78,6 @@ class ImportConfigListener implements EventSubscriberInterface
     protected function cleanupImportConfigs(string $condition): void
     {
         $db = Db::get();
-        $db->executeQuery('DELETE FROM importconfigs where ' . $condition);
+        $db->executeStatement('DELETE FROM importconfigs WHERE ' . $condition);
     }
 }

--- a/src/GDPR/DataProvider/OpenDxpUsers.php
+++ b/src/GDPR/DataProvider/OpenDxpUsers.php
@@ -123,7 +123,10 @@ class OpenDxpUsers implements DataProviderInterface
     {
         $db = Db::get();
 
-        return $db->fetchAllAssociative("SELECT ctype, cid, note, FROM_UNIXTIME(`date`) AS 'date' FROM versions WHERE userId = ?", [$user->getId()]);
+        return $db->fetchAllAssociative(
+            'SELECT ctype, cid, note, FROM_UNIXTIME(`date`) AS "date" FROM versions WHERE userId = ?',
+            [$user->getId()]
+        );
     }
 
     protected function getUsageLogDataForUser(User\AbstractUser $user): array

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -62,7 +62,7 @@ class Installer extends SettingsStoreAwareInstaller
     {
         $db = \OpenDxp\Db::get();
 
-        $existingKeys = $db->fetchFirstColumn('SELECT ' . $db->quoteIdentifier('key') . ' FROM users_permission_definitions');
+        $existingKeys = $db->fetchFirstColumn(sprintf('SELECT %s FROM users_permission_definitions', $db->quoteIdentifier('key')));
 
         foreach (self::USER_PERMISSIONS as $permission) {
             if (in_array($permission, $existingKeys)) {
@@ -107,7 +107,7 @@ class Installer extends SettingsStoreAwareInstaller
                 continue;
             }
 
-            $this->db->executeQuery($statement);
+            $this->db->executeStatement($statement);
         }
     }
 
@@ -123,7 +123,7 @@ class Installer extends SettingsStoreAwareInstaller
                 continue;
             }
 
-            $this->db->executeQuery("DROP TABLE IF EXISTS $table");
+            $this->db->executeStatement(sprintf('DROP TABLE IF EXISTS %s', $this->db->quoteIdentifier($table)));
         }
     }
 

--- a/src/Model/GridConfigShare/Dao.php
+++ b/src/Model/GridConfigShare/Dao.php
@@ -31,7 +31,10 @@ class Dao extends Model\Dao\AbstractDao
      */
     public function getByGridConfigAndSharedWithId(int $gridConfigId, int $sharedWithUserId): void
     {
-        $data = $this->db->fetchAssociative('SELECT * FROM gridconfig_shares WHERE gridConfigId = ? AND sharedWithUserId = ?', [$gridConfigId, $sharedWithUserId]);
+        $data = $this->db->fetchAssociative(
+            'SELECT * FROM gridconfig_shares WHERE gridConfigId = ? AND sharedWithUserId = ?',
+            [$gridConfigId, $sharedWithUserId]
+        );
 
         if (!$data) {
             throw new Model\Exception\NotFoundException('gridconfig share with gridConfigId ' . $gridConfigId . ' and shared with ' . $sharedWithUserId . ' not found');


### PR DESCRIPTION
  Audit and cleanup of all raw SQL queries across the codebase (~114 query sites).

  - Replace `executeQuery()` with `executeStatement()` for all DML (INSERT/UPDATE/DELETE)
  - Eliminate `$db->quote()` value embedding in favor of `?` / `:name` parameter bindings
  - Refactor `buildConditionPartsFromDescriptor()` to return `[$conditions, $params]` instead of inlining quoted values
  - Replace string concatenation for dynamic table names with `sprintf()`
  - Apply consistent style: single-quoted PHP strings, SQL keywords uppercase, multi-line formatting for long queries, no trailing semicolons

### Deprecations
- `OpenDxp\Db\Helper::fetchPairs` => No replacement
- `OpenDxp\Db\Helper::selectAndDeleteWhere` => No replacement
- `OpenDxp\Db\Helper::quoteInto` => Use parameterized queries with ? or :name placeholders instead.