### PR TITLE
remove redundant translation cache clearing from TranslationController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog / Upgrade Notes
 
+## 1.3.2
+* Bugfix: Remove redundant translation cache clearing from TranslationController
+
 ## 1.3.1
 * Bugfix: Add guard clause to prevent rendering site settings without a valid site
 

--- a/src/Controller/Admin/TranslationController.php
+++ b/src/Controller/Admin/TranslationController.php
@@ -153,9 +153,6 @@ class TranslationController extends AdminAbstractController
         $translation->setDomain($domain);
         $tableName = $translation->getDao()->getDatabaseTableName();
 
-        // clear translation cache
-        Translation::clearDependentCache();
-
         $list = new Translation\Listing();
         $list->setDomain($domain);
 
@@ -322,9 +319,6 @@ class TranslationController extends AdminAbstractController
         $translation = new Translation();
         $translation->setDomain($domain);
         $tableName = $translation->getDao()->getDatabaseTableName();
-
-        // clear translation cache
-        Translation::clearDependentCache();
 
         if ($request->request->has('data')) {
             $data = $this->decodeJson($request->request->get('data'));


### PR DESCRIPTION
Remove redundant `Translation::clearDependentCache()` calls from `TranslationController`

- Remove premature cache clear in translationsAction() before save()
  (`save()` already calls `clearDependentCache()` internally)
- Remove unnecessary cache clear in `exportAction()`
  (export does not modify data, no cache invalidation needed)