### PR TITLE
fix: array thumbnail parameter in getImageThumbnailAction

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -1168,8 +1168,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $thumbnailConfig = null;
 
-        if ($request->query->get('thumbnail')) {
-            $thumbnailConfig = $image->getThumbnail($request->query->get('thumbnail'))->getConfig();
+        if ($thumbnailParam = $request->query->all()['thumbnail'] ?? null) {
+            $thumbnailConfig = $image->getThumbnail($thumbnailParam)->getConfig();
         }
         if (!$thumbnailConfig) {
             if ($request->query->get('config')) {

--- a/tests/Unit/Controller/Asset/GetImageThumbnailQueryParamTest.php
+++ b/tests/Unit/Controller/Asset/GetImageThumbnailQueryParamTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * OpenDXP
+ *
+ * This source file is licensed under the GNU General Public License version 3 (GPLv3).
+ *
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (https://pimcore.com)
+ * @copyright  Modification Copyright (c) OpenDXP (https://www.opendxp.io)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.html  GNU General Public License version 3 (GPLv3)
+ */
+
+namespace OpenDxp\Bundle\AdminBundle\Tests\Unit\Controller\Asset;
+
+use OpenDxp\Bundle\AdminBundle\Tests\Support\Test\UnitTestCase;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Covers the InputBag workaround in AssetController::getImageThumbnailAction().
+ *
+ * InputBag::get() rejects non-scalar values (Symfony 5.1+), but the `thumbnail`
+ * param can legitimately be an array (inline config) or a string (named config).
+ * The fix reads via ->all()['thumbnail'] to bypass the scalar-only restriction.
+ */
+class GetImageThumbnailQueryParamTest extends UnitTestCase
+{
+    public function testGetThrowsForArrayThumbnailParam(): void
+    {
+        $request = Request::create('/get-image-thumbnail', 'GET', [
+            'thumbnail' => ['width' => 100, 'height' => 200],
+        ]);
+
+        $this->expectException(BadRequestException::class);
+
+        $request->query->get('thumbnail');
+    }
+
+    public function testAllReturnsArrayThumbnailParam(): void
+    {
+        $request = Request::create('/get-image-thumbnail', 'GET', [
+            'thumbnail' => ['width' => 100, 'height' => 200],
+        ]);
+
+        $thumbnailParam = $request->query->all()['thumbnail'] ?? null;
+
+        self::assertSame(['width' => 100, 'height' => 200], $thumbnailParam);
+    }
+
+    public function testAllReturnsStringThumbnailParam(): void
+    {
+        $request = Request::create('/get-image-thumbnail', 'GET', [
+            'thumbnail' => 'my-thumbnail-config',
+        ]);
+
+        $thumbnailParam = $request->query->all()['thumbnail'] ?? null;
+
+        self::assertSame('my-thumbnail-config', $thumbnailParam);
+    }
+
+    public function testAbsentThumbnailParamYieldsNull(): void
+    {
+        $request = Request::create('/get-image-thumbnail', 'GET', ['id' => '42']);
+
+        $thumbnailParam = $request->query->all()['thumbnail'] ?? null;
+
+        self::assertNull($thumbnailParam);
+    }
+}


### PR DESCRIPTION
## Changes in this pull request
Fix `getImageThumbnailAction` crash when `thumbnail` query param is an array.

PR #39 replaced `$request->get()` with `$request->query->get()` across controllers to address the Symfony 7.4 deprecation. That was correct in general, but `thumbnail` is a special case: it accepts both a string (named config) and an array (inline config). `InputBag::get()` throws `BadRequestException` for non-scalar values since Symfony 5.1+, so the array case broke.

This can be easily triggered by declaring a dynamic configuration inside twig:
```
{{ opendxp_image('test_image', {
        'thumbnail': {
            'width': 500,
            'aspectratio': true,
            'interlace': true,
            'quality': 85,
            'format': 'png'
        }
}) }}
```

```log
Symfony\Component\HttpFoundation\Exception\BadRequestException:
Input value "thumbnail" contains a non-scalar value.

  at vendor/symfony/http-foundation/InputBag.php:46
  at Symfony\Component\HttpFoundation\InputBag->get('thumbnail')
     (vendor/open-dxp/admin-bundle/src/Controller/Admin/Asset/AssetController.php:1171)
  at OpenDxp\Bundle\AdminBundle\Controller\Admin\Asset\AssetController->getImageThumbnailAction(object(Request))
     (vendor/symfony/http-kernel/HttpKernel.php:183)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:193)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (vendor/symfony/runtime/Runner/Symfony/HttpKernelRunner.php:35)
  at Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
     (vendor/autoload_runtime.php:32)
  at require_once('/var/www/html/vendor/autoload_runtime.php')
     (public/index.php:17)               
```

**Fix:**
Read via `->all()['thumbnail'] ?? null` which bypasses the scalar restriction and handles both value shapes without throwing.

**Changes:**
- `AssetController::getImageThumbnailAction`: replace `->get('thumbnail')` with `->all()['thumbnail'] ?? null`
- Add `GetImageThumbnailQueryParamTest`