### PR TITLE
Fix missing OpenDXP CSS vars

### DIFF
--- a/templates/admin/login/layout.html.twig
+++ b/templates/admin/login/layout.html.twig
@@ -26,7 +26,7 @@
         <style>
             #content button {
                 background: {{ customColor }};
-                color: var(--color-white);
+                color: var(--color-opendxp-white);
             }
 
             #content a {

--- a/templates/admin/misc/admin_css.html.twig
+++ b/templates/admin/misc/admin_css.html.twig
@@ -55,7 +55,7 @@
 }
 
 #opendxp_notification > span.notification-icon {
-    background: var(--color-white) !important;
+    background: var(--color-opendxp-white) !important;
 }
 
 #opendxp_signet {
@@ -68,4 +68,3 @@
 }
 {% endif %}
 {% endif %}
-


### PR DESCRIPTION
## Summary
- replace the two remaining `--color-white` references with `--color-opendxp-white`
- restore the renamed CSS variable usage in the login button and admin notification icon styling

Closes #98
